### PR TITLE
[codex] fix HAL type rebind race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "eerie"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eerie"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Gyungmin Myung"]

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -56,6 +56,39 @@ fn with_hal_type_adapters<T>(
     })
 }
 
+fn rebind_hal_refs<T: Type>(instance: &Instance, list: &List<T>) -> Result<(), RuntimeError> {
+    let count = unsafe { sys::iree_vm_list_size(list.ctx) };
+    for index in 0..count {
+        let mut value = sys::iree_vm_ref_t::default();
+        let status = base::Status::from_raw(unsafe {
+            sys::iree_vm_list_get_ref_assign(list.ctx, index, &mut value)
+        });
+        if status.to_result().is_err()
+            || value.type_
+                == sys::iree_vm_ref_type_bits_t_IREE_VM_REF_TYPE_NULL as sys::iree_vm_ref_type_t
+        {
+            continue;
+        }
+
+        let type_name = string_view_to_string(unsafe { sys::iree_vm_ref_type_name(value.type_) });
+        if !type_name.starts_with("hal.") {
+            continue;
+        }
+
+        let rebound_type = instance.lookup_type(&type_name);
+        if rebound_type == 0 || rebound_type == value.type_ {
+            continue;
+        }
+
+        value.type_ = rebound_type;
+        base::Status::from_raw(unsafe {
+            sys::iree_vm_list_set_ref_retain(list.ctx, index, &value)
+        })
+        .to_result()?;
+    }
+    Ok(())
+}
+
 /// A VM instance owns registered VM ref types and VM-level host allocation.
 pub struct Instance {
     pub(crate) ctx: *mut sys::iree_vm_instance_t,
@@ -490,6 +523,7 @@ impl Function {
         O: Type,
     {
         with_hal_type_adapters(&self.context.instance, || {
+            rebind_hal_refs(&self.context.instance, inputs)?;
             base::Status::from_raw(unsafe {
                 trace!("iree_vm_invoke");
                 sys::iree_vm_invoke(

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -310,6 +310,51 @@ fn invoke_after_newer_instance_rebinds_hal_types() {
 }
 
 #[test]
+fn invoke_rebinds_prepared_hal_argument_refs() {
+    let vmfb = include_bytes!("mul_vmvx.vmfb");
+    let instance = runtime::vm::Instance::new().unwrap();
+    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
+    let driver = registry.create_driver("local-sync").unwrap();
+    let device = driver.create_default_device().unwrap();
+    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
+    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
+    let context =
+        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
+    let function = context.resolve_function("arithmetic.simple_mul").unwrap();
+
+    let input_data = Vec::from_iter((0..100).map(|i| i as f32));
+    let input = BufferView::<f32>::from_host(
+        &device,
+        &[100],
+        Encoding::DenseRowMajor,
+        input_data.as_slice(),
+    )
+    .unwrap();
+    let mut input_list = List::<Undefined>::new(2, &instance).unwrap();
+    input_list
+        .push_ref(&input.to_ref(&instance).unwrap())
+        .unwrap();
+    input_list
+        .push_ref(&input.to_ref(&instance).unwrap())
+        .unwrap();
+
+    let _newer_instance = runtime::vm::Instance::new().unwrap();
+
+    let mut output_list = List::<Undefined>::new(1, &instance).unwrap();
+    function.invoke(&input_list, &mut output_list).unwrap();
+    let output = output_list
+        .get_ref::<BufferView<f32>>(0)
+        .unwrap()
+        .to_buffer_view()
+        .unwrap()
+        .read_to_vec(&device)
+        .unwrap();
+    assert_eq!(output[0], 0.0);
+    assert_eq!(output[7], 49.0);
+    assert_eq!(output[99], 9801.0);
+}
+
+#[test]
 fn parallel_instance_invocations_rebind_hal_types() {
     let mut threads = Vec::new();
     for _ in 0..2 {


### PR DESCRIPTION
## Summary

Fixes #26 by closing the race between HAL type adapter rebinding and VM invocation.

## Root Cause

IREE HAL type adapters are process-global statics that get rebound by `iree_hal_module_resolve_all_types(instance)`. The Rust wrapper already serialized adapter resolution and `iree_vm_invoke`, but callers could prepare HAL refs in input lists before another instance rebound those adapters. Under parallel release-mode tests, native HAL imports such as `hal.buffer.assert` could then observe refs whose type tags were stale for the currently resolved adapter state, producing `INVALID_ARGUMENT; ref type mismatch`.

## Changes

- Rebind HAL refs already present in a function input list to the function context's VM instance immediately before `iree_vm_invoke`, while the HAL adapter lock is held.
- Add a regression test that prepares HAL argument refs, creates a newer instance to force HAL rebinding, and invokes using the prebuilt list.
- Keep the existing parallel coverage intact.

## Validation

Ran locally under `nix develop`:

```sh
cargo test --release --test runtime -- --nocapture
cargo test --release
```

Both passed.