### PR TITLE
Add Bool8 buffer element support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Typed tensor-shaped runtime values are represented by `runtime::hal::BufferView<
 Function calls use VM `List` values directly: convert input buffer views with
 `ToRef`, call `runtime::vm::Function::invoke`, then extract output
 `Ref<BufferView<T>>` values from the output list.
+Supported `BufferView<T>` element types are `bool` (IREE Bool8), signed and
+unsigned 8/16/32/64-bit integers, `f16`, `bf16`, `f32`, and `f64`.
 
 #### MacOS
 Install XCode and MacOS SDKs.

--- a/src/runtime/hal.rs
+++ b/src/runtime/hal.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::{format, string::String, vec::Vec};
+use alloc::{borrow::Cow, format, string::String, vec::Vec};
 use core::{
     fmt::{Debug, Formatter},
     marker::PhantomData,
@@ -425,12 +425,26 @@ impl From<sys::iree_hal_element_type_t> for ElementType {
     }
 }
 
-/// A scalar element type that can be copied to and from raw HAL buffer storage.
+/// A scalar element type that can be copied to and from HAL buffer storage.
 ///
-/// This trait is sealed because `BufferView` reads device bytes directly into
-/// `Vec<T>`. Only types with plain byte representations should implement it.
+/// This trait is sealed so the runtime wrapper can preserve Rust validity
+/// invariants while decoding raw device bytes.
 pub trait BufferElement: Copy + private::Sealed {
+    #[doc(hidden)]
+    const IS_RAW_STORAGE_COMPATIBLE: bool;
+
     fn element_type() -> ElementType;
+
+    #[doc(hidden)]
+    fn element_size() -> usize {
+        core::mem::size_of::<Self>()
+    }
+
+    #[doc(hidden)]
+    fn as_bytes(data: &[Self]) -> Cow<'_, [u8]>;
+
+    #[doc(hidden)]
+    fn decode_slice(bytes: &[u8]) -> Result<Vec<Self>, RuntimeError>;
 }
 
 macro_rules! impl_buffer_element {
@@ -438,8 +452,44 @@ macro_rules! impl_buffer_element {
         impl private::Sealed for $type {}
 
         impl BufferElement for $type {
+            const IS_RAW_STORAGE_COMPATIBLE: bool = true;
+
             fn element_type() -> ElementType {
                 ElementType::$variant
+            }
+
+            fn as_bytes(data: &[Self]) -> Cow<'_, [u8]> {
+                let bytes = unsafe {
+                    core::slice::from_raw_parts(
+                        data.as_ptr() as *const u8,
+                        core::mem::size_of_val(data),
+                    )
+                };
+                Cow::Borrowed(bytes)
+            }
+
+            fn decode_slice(bytes: &[u8]) -> Result<Vec<Self>, RuntimeError> {
+                let element_size = Self::element_size();
+                debug_assert_ne!(element_size, 0);
+                if !bytes.len().is_multiple_of(element_size) {
+                    return Err(RuntimeError::InvalidArgument(format!(
+                        "buffer byte length {} is not divisible by element size {}",
+                        bytes.len(),
+                        element_size
+                    )));
+                }
+
+                let element_len = bytes.len() / element_size;
+                let mut data = Vec::<Self>::with_capacity(element_len);
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        bytes.as_ptr(),
+                        data.as_mut_ptr() as *mut u8,
+                        bytes.len(),
+                    );
+                    data.set_len(element_len);
+                }
+                Ok(data)
             }
         }
     };
@@ -457,6 +507,34 @@ impl_buffer_element!(f32, Float32);
 impl_buffer_element!(f64, Float64);
 impl_buffer_element!(f16, Float16);
 impl_buffer_element!(bf16, BFloat16);
+
+impl private::Sealed for bool {}
+
+impl BufferElement for bool {
+    const IS_RAW_STORAGE_COMPATIBLE: bool = false;
+
+    fn element_type() -> ElementType {
+        ElementType::Bool8
+    }
+
+    fn as_bytes(data: &[Self]) -> Cow<'_, [u8]> {
+        Cow::Owned(data.iter().map(|&value| u8::from(value)).collect())
+    }
+
+    fn decode_slice(bytes: &[u8]) -> Result<Vec<Self>, RuntimeError> {
+        bytes
+            .iter()
+            .enumerate()
+            .map(|(index, &value)| match value {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(RuntimeError::InvalidArgument(format!(
+                    "invalid Bool8 value {value} at element {index}; expected 0 or 1"
+                ))),
+            })
+            .collect()
+    }
+}
 
 pub type MemoryType = sys::iree_hal_memory_type_t;
 pub type MemoryAccess = sys::iree_hal_memory_access_t;
@@ -616,12 +694,10 @@ impl<T: BufferElement> BufferView<T> {
         }
 
         let mut ctx = core::ptr::null_mut();
-        let bytes: ConstByteSpan = unsafe {
-            core::slice::from_raw_parts(data.as_ptr() as *const u8, core::mem::size_of_val(data))
-        }
-        .into();
+        let encoded = T::as_bytes(data);
+        let bytes: ConstByteSpan = encoded.as_ref().into();
         debug!("shape: {:?}", shape);
-        debug!("data len: {}", core::mem::size_of_val(data));
+        debug!("data len: {}", encoded.len());
         base::Status::from_raw(unsafe {
             sys::iree_hal_buffer_view_allocate_buffer_copy(
                 device.ctx,
@@ -671,17 +747,14 @@ impl<T: BufferElement> BufferView<T> {
         shape: &[usize],
         encoding: Encoding,
     ) -> Result<Self, RuntimeError> {
-        let expected_byte_length =
-            shape
-                .iter()
-                .try_fold(core::mem::size_of::<T>(), |product, dim| {
-                    product.checked_mul(*dim).ok_or_else(|| {
-                        RuntimeError::InvalidArgument(format!(
-                            "buffer shape {:?} overflows usize byte count",
-                            shape
-                        ))
-                    })
-                })?;
+        let expected_byte_length = shape.iter().try_fold(T::element_size(), |product, dim| {
+            product.checked_mul(*dim).ok_or_else(|| {
+                RuntimeError::InvalidArgument(format!(
+                    "buffer shape {:?} overflows usize byte count",
+                    shape
+                ))
+            })
+        })?;
         if expected_byte_length > buffer.byte_length() {
             return Err(RuntimeError::InvalidArgument(format!(
                 "buffer view requires {} bytes, buffer has {} bytes",
@@ -758,11 +831,12 @@ impl<T: BufferElement> BufferView<T> {
                 data.len()
             )));
         }
-        let byte_length = core::mem::size_of_val(data);
+        let encoded = T::as_bytes(data);
+        let byte_length = encoded.len();
         base::Status::from_raw(unsafe {
             sys::iree_hal_device_transfer_h2d(
                 device.ctx,
-                data.as_ptr() as *const core::ffi::c_void,
+                encoded.as_ref().as_ptr() as *const core::ffi::c_void,
                 self.buffer(),
                 0,
                 byte_length,
@@ -810,22 +884,42 @@ impl<T: BufferElement> BufferView<T> {
             )));
         }
         let byte_length = self.byte_length();
-        let element_size = core::mem::size_of::<T>();
-        debug_assert_ne!(element_size, 0);
-        if !byte_length.is_multiple_of(element_size) {
-            return Err(RuntimeError::InvalidArgument(format!(
-                "buffer byte length {} is not divisible by element size {}",
-                byte_length, element_size
-            )));
+        if T::IS_RAW_STORAGE_COMPATIBLE {
+            let element_size = T::element_size();
+            debug_assert_ne!(element_size, 0);
+            if !byte_length.is_multiple_of(element_size) {
+                return Err(RuntimeError::InvalidArgument(format!(
+                    "buffer byte length {} is not divisible by element size {}",
+                    byte_length, element_size
+                )));
+            }
+
+            let mut data = Vec::<T>::with_capacity(byte_length / element_size);
+            base::Status::from_raw(unsafe {
+                sys::iree_hal_device_transfer_d2h(
+                    device.ctx,
+                    self.buffer(),
+                    0,
+                    data.as_mut_ptr() as *mut core::ffi::c_void,
+                    byte_length,
+                    sys::iree_hal_transfer_buffer_flag_bits_t_IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
+                    infinite_timeout(),
+                )
+            })
+            .to_result()?;
+            unsafe {
+                data.set_len(byte_length / element_size);
+            }
+            return Ok(data);
         }
 
-        let mut data = Vec::<T>::with_capacity(byte_length / element_size);
+        let mut bytes = Vec::<u8>::with_capacity(byte_length);
         base::Status::from_raw(unsafe {
             sys::iree_hal_device_transfer_d2h(
                 device.ctx,
                 self.buffer(),
                 0,
-                data.as_mut_ptr() as *mut core::ffi::c_void,
+                bytes.as_mut_ptr() as *mut core::ffi::c_void,
                 byte_length,
                 sys::iree_hal_transfer_buffer_flag_bits_t_IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
                 infinite_timeout(),
@@ -833,9 +927,9 @@ impl<T: BufferElement> BufferView<T> {
         })
         .to_result()?;
         unsafe {
-            data.set_len(byte_length / element_size);
+            bytes.set_len(byte_length);
         }
-        Ok(data)
+        T::decode_slice(&bytes)
     }
 }
 
@@ -873,7 +967,12 @@ impl<T: BufferElement> Drop for BufferView<T> {
 pub struct BufferMapping<T: BufferElement> {
     ctx: sys::iree_hal_buffer_mapping_t,
     _buffer: BufferView<T>,
-    element_len: usize,
+    data: BufferMappingData<T>,
+}
+
+enum BufferMappingData<T> {
+    Mapped { element_len: usize },
+    Owned(Vec<T>),
 }
 
 impl<T: BufferElement> BufferMapping<T> {
@@ -900,18 +999,6 @@ impl<T: BufferElement> BufferMapping<T> {
         })
         .to_result()?;
         let mut ctx = unsafe { out.assume_init() };
-        let element_size = core::mem::size_of::<T>();
-        debug_assert_ne!(element_size, 0);
-        if !ctx.contents.data_length.is_multiple_of(element_size) {
-            unsafe {
-                sys::iree_hal_buffer_unmap_range(&mut ctx);
-            }
-            return Err(RuntimeError::InvalidArgument(format!(
-                "mapped byte length {} is not divisible by element size {}",
-                ctx.contents.data_length, element_size
-            )));
-        }
-        let align = core::mem::align_of::<T>();
         let address = ctx.contents.data as usize;
         if ctx.contents.data_length != 0 && address == 0 {
             unsafe {
@@ -921,27 +1008,70 @@ impl<T: BufferElement> BufferMapping<T> {
                 "mapped buffer returned null data for a non-empty range",
             )));
         }
-        if address != 0 && !address.is_multiple_of(align) {
-            unsafe {
-                sys::iree_hal_buffer_unmap_range(&mut ctx);
+        let data = if T::IS_RAW_STORAGE_COMPATIBLE {
+            let element_size = T::element_size();
+            debug_assert_ne!(element_size, 0);
+            if !ctx.contents.data_length.is_multiple_of(element_size) {
+                unsafe {
+                    sys::iree_hal_buffer_unmap_range(&mut ctx);
+                }
+                return Err(RuntimeError::InvalidArgument(format!(
+                    "mapped byte length {} is not divisible by element size {}",
+                    ctx.contents.data_length, element_size
+                )));
             }
-            return Err(RuntimeError::InvalidArgument(format!(
-                "mapped buffer address 0x{address:x} is not aligned to {align}"
-            )));
-        }
-        let element_len = ctx.contents.data_length / element_size;
+            let align = core::mem::align_of::<T>();
+            if address != 0 && !address.is_multiple_of(align) {
+                unsafe {
+                    sys::iree_hal_buffer_unmap_range(&mut ctx);
+                }
+                return Err(RuntimeError::InvalidArgument(format!(
+                    "mapped buffer address 0x{address:x} is not aligned to {align}"
+                )));
+            }
+            BufferMappingData::Mapped {
+                element_len: ctx.contents.data_length / element_size,
+            }
+        } else {
+            let bytes = if ctx.contents.data_length == 0 {
+                &[]
+            } else {
+                unsafe {
+                    core::slice::from_raw_parts(
+                        ctx.contents.data as *const u8,
+                        ctx.contents.data_length,
+                    )
+                }
+            };
+            match T::decode_slice(bytes) {
+                Ok(data) => BufferMappingData::Owned(data),
+                Err(err) => {
+                    unsafe {
+                        sys::iree_hal_buffer_unmap_range(&mut ctx);
+                    }
+                    return Err(err);
+                }
+            }
+        };
         Ok(Self {
             ctx,
             _buffer: buffer,
-            element_len,
+            data,
         })
     }
 
     pub fn data(&self) -> &[T] {
-        if self.element_len == 0 {
-            return &[];
+        match &self.data {
+            BufferMappingData::Mapped { element_len } => {
+                if *element_len == 0 {
+                    return &[];
+                }
+                unsafe {
+                    core::slice::from_raw_parts(self.ctx.contents.data as *const T, *element_len)
+                }
+            }
+            BufferMappingData::Owned(data) => data,
         }
-        unsafe { core::slice::from_raw_parts(self.ctx.contents.data as *const T, self.element_len) }
     }
 }
 

--- a/tests/bool.mlir
+++ b/tests/bool.mlir
@@ -1,0 +1,7 @@
+module @bools {
+  func.func @logical_not(%arg0: tensor<4xi1>) -> tensor<4xi1> {
+    %true = arith.constant dense<true> : tensor<4xi1>
+    %0 = arith.xori %arg0, %true : tensor<4xi1>
+    return %0 : tensor<4xi1>
+  }
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -115,6 +115,69 @@ fn fp16_buffer() {
 }
 
 #[test]
+fn bool_buffer_roundtrip_read_write_copy_and_mapping() {
+    let (_registry, _driver, device) = local_sync_device();
+    let buffer = BufferView::<bool>::from_host(
+        &device,
+        &[2, 2],
+        Encoding::DenseRowMajor,
+        &[true, false, true, false],
+    )
+    .unwrap();
+
+    assert_eq!(buffer.element_type(), ElementType::Bool8);
+    assert_eq!(buffer.element_size(), core::mem::size_of::<bool>());
+    assert_eq!(
+        buffer.read_to_vec(&device).unwrap(),
+        vec![true, false, true, false]
+    );
+
+    let mapping = BufferMapping::map_read(&buffer).unwrap();
+    assert_eq!(mapping.data(), &[true, false, true, false]);
+    drop(mapping);
+
+    buffer
+        .write_from_slice(&device, &[false, true, false, true])
+        .unwrap();
+    assert_eq!(
+        buffer.read_to_vec(&device).unwrap(),
+        vec![false, true, false, true]
+    );
+
+    let target = BufferView::<bool>::from_host(
+        &device,
+        &[2, 2],
+        Encoding::DenseRowMajor,
+        &[false, false, false, false],
+    )
+    .unwrap();
+    buffer.copy_to(&device, &target).unwrap();
+    assert_eq!(
+        target.read_to_vec(&device).unwrap(),
+        vec![false, true, false, true]
+    );
+}
+
+#[test]
+fn bool_buffer_rejects_invalid_bool8_bytes() {
+    let (_registry, _driver, device) = local_sync_device();
+    let buffer = Buffer::allocate(&device, 1, BufferParams::default()).unwrap();
+    let raw_view = BufferView::<u8>::from_buffer(&buffer, &[1], Encoding::DenseRowMajor).unwrap();
+    raw_view.write_from_slice(&device, &[2]).unwrap();
+
+    let bool_view =
+        BufferView::<bool>::from_buffer(&buffer, &[1], Encoding::DenseRowMajor).unwrap();
+    let err = bool_view.read_to_vec(&device).unwrap_err();
+    assert!(format!("{err}").contains("invalid Bool8 value 2"));
+
+    let err = match BufferMapping::map_read(&bool_view) {
+        Ok(_) => panic!("invalid Bool8 mapping succeeded"),
+        Err(err) => err,
+    };
+    assert!(format!("{err}").contains("invalid Bool8 value 2"));
+}
+
+#[test]
 fn buffer_metadata() {
     let (_registry, _driver, device) = local_sync_device();
     let buffer = BufferView::<f32>::from_host(
@@ -418,6 +481,40 @@ fn invoke_mul_function(
         .unwrap()
 }
 
+fn run_bool_not(vmfb: &[u8], driver_name: &str) -> Vec<bool> {
+    let instance = runtime::vm::Instance::new().unwrap();
+    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
+    let driver = registry.create_driver(driver_name).unwrap();
+    let device = driver.create_default_device().unwrap();
+    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
+    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
+    let context =
+        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
+    let function = context.resolve_function("bools.logical_not").unwrap();
+
+    let input = BufferView::<bool>::from_host(
+        &device,
+        &[4],
+        Encoding::DenseRowMajor,
+        &[true, false, false, true],
+    )
+    .unwrap();
+
+    let mut input_list = List::<Undefined>::new(1, &instance).unwrap();
+    input_list
+        .push_ref(&input.to_ref(&instance).unwrap())
+        .unwrap();
+    let mut output_list = List::<Undefined>::new(1, &instance).unwrap();
+    function.invoke(&input_list, &mut output_list).unwrap();
+    output_list
+        .get_ref::<BufferView<bool>>(0)
+        .unwrap()
+        .to_buffer_view()
+        .unwrap()
+        .read_to_vec(&device)
+        .unwrap()
+}
+
 #[cfg(feature = "compiler")]
 mod integration_tests {
     use eerie::compiler;
@@ -425,7 +522,7 @@ mod integration_tests {
     use std::path::Path;
     use std::sync::Mutex;
 
-    use super::run_mul;
+    use super::{run_bool_not, run_mul};
 
     static COMPILER: Mutex<Option<compiler::Compiler>> = Mutex::new(None);
 
@@ -438,6 +535,14 @@ mod integration_tests {
     }
 
     fn compile_mul(target_backend: &str) -> Vec<u8> {
+        compile_mlir(target_backend, Path::new("tests/mul.mlir"))
+    }
+
+    fn compile_bool_not(target_backend: &str) -> Vec<u8> {
+        compile_mlir(target_backend, Path::new("tests/bool.mlir"))
+    }
+
+    fn compile_mlir(target_backend: &str, path: &Path) -> Vec<u8> {
         init_compiler();
         let compiler = COMPILER.lock().unwrap();
         let mut compiler_session = compiler.as_ref().unwrap().create_session();
@@ -446,9 +551,7 @@ mod integration_tests {
             flags.push("--iree-metal-compile-to-metallib=false".to_string());
         }
         compiler_session.set_flags(flags).unwrap();
-        let source = compiler_session
-            .create_source_from_file(Path::new("tests/mul.mlir"))
-            .unwrap();
+        let source = compiler_session.create_source_from_file(path).unwrap();
         let mut invocation = compiler_session.create_invocation();
         let mut output = compiler::MemBufferOutput::new(compiler.as_ref().unwrap()).unwrap();
         invocation
@@ -472,6 +575,13 @@ mod integration_tests {
         assert_eq!(output[0], 0.0);
         assert_eq!(output[7], 49.0);
         assert_eq!(output[99], 9801.0);
+    }
+
+    #[test]
+    fn bool_buffer_view_invoke() {
+        let vmfb = compile_bool_not("llvm-cpu");
+        let output = run_bool_not(&vmfb, "local-sync");
+        assert_eq!(output, vec![false, true, true, false]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds safe `BufferView<bool>` support backed by IREE Bool8 encoding.
- Routes host buffer writes, reads, and read mappings through sealed element encode/decode hooks so Bool8 bytes are validated before becoming Rust `bool` values.
- Keeps raw-compatible numeric element types on the existing direct transfer and zero-copy mapping paths.
- Adds bool buffer roundtrip/invalid-byte tests and a compiler-gated bool runtime invocation fixture.
- Documents the supported `BufferView<T>` element set.

This unblocks gmmyung/knok#22 by allowing bool tensors to pass through the hosted runtime safely.

## Validation

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo check --no-default-features`
- `nix develop -c cargo test --no-default-features --features runtime,std --test runtime -- --test-threads=1`
- `nix develop -c cargo test --features compiler,runtime,std --test runtime bool_buffer_view_invoke -- --test-threads=1`
- `nix develop -c cargo test --features compiler,runtime,std --test runtime -- --test-threads=1`

## Notes

- No upstream IREE code changes are included.
- I initialized the vendored IREE third-party submodules locally to run the runtime tests.
- `eerie-sys` already exposes the Bool8 element type constant, so no new sys binding was required.