### PR TITLE
Bump eerie to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.3 - 2026-06-22
+
+### Added
+
+- Added safe `BufferView<bool>` support for IREE Bool8 tensors, including host buffer creation, writes, reads, read mappings, VM ref extraction, and runtime invocation paths.
+- Added Bool8 validation when reading bool buffer contents so invalid byte values cannot become invalid Rust `bool` values.
+
+### Notes
+
+- Raw-compatible numeric buffer element types keep their existing direct host transfer and zero-copy read mapping paths.
+- `eerie-sys` remains at `0.3.2`; Bool8 constants were already available in the generated raw bindings.
+
 ## 0.4.1 - 2026-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "eerie"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eerie"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Gyungmin Myung"]


### PR DESCRIPTION
## Summary

- Bumps the safe wrapper crate version from `0.4.2` to `0.4.3`.
- Adds a `0.4.3` changelog entry for Bool8 buffer support.
- Leaves `eerie-sys` at `0.3.2` because no raw binding changes were required.

## Validation

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo check --no-default-features`
- `nix develop -c cargo test --features compiler,runtime,std --test runtime -- --test-threads=1`