### PR TITLE
Use global VM instance handles

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,4 @@ jobs:
         LIB_IREE_COMPILER = \"${library_path}\"" > .cargo/config.toml
         
     - name: Run tests
-      # Serialize runtime tests while IREE multi-instance HAL type registration
-      # is under investigation: https://github.com/iree-org/iree/issues/24615
-      run: RUST_BACKTRACE=1 cargo test -vv --release -- --test-threads=1
+      run: RUST_BACKTRACE=1 cargo test -vv --release

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ fn run_vmfb(vmfb: &[u8]) -> Vec<f32> {
     use eerie::runtime::*;
     use eerie::runtime::vm::ToRef;
 
-    let instance = vm::Instance::new().unwrap();
+    let instance = vm::Instance::global().unwrap();
     let registry = hal::DriverRegistry::with_available_drivers().unwrap();
     let driver = registry.create_driver("local-task").unwrap();
     let device = driver.create_default_device().unwrap();
@@ -102,6 +102,14 @@ The crate is divided into two sections: compiler and runtime. You can enable eac
 
 ### Runtime
 Eerie builds the IREE runtime from source during compilation. CMake, Clang are required.
+
+`runtime::vm::Instance::global()` returns a retained handle to the process-wide VM
+instance; it does not create an independent IREE VM instance. IREE expects VM
+instances to be reused across contexts, and HAL type registration uses
+process-global adapter state.
+The root VM instance is retained for the lifetime of the process or embedded
+program. Dropping an `Instance` releases the returned handle, but does not tear
+down the shared runtime root.
 
 Typed tensor-shaped runtime values are represented by `runtime::hal::BufferView<T>`.
 Function calls use VM `List` values directly: convert input buffer views with

--- a/README.md
+++ b/README.md
@@ -63,36 +63,18 @@ Running a buffer view operation in an IREE runtime environment
 ```rust
 #[cfg(feature = "runtime")]
 fn run_vmfb(vmfb: &[u8]) -> Vec<f32> {
-    use eerie::runtime::*;
-    use eerie::runtime::vm::ToRef;
+    use eerie::runtime::{BufferView, Driver, Runtime};
 
-    let instance = vm::Instance::global().unwrap();
-    let registry = hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver("local-task").unwrap();
-    let device = driver.create_default_device().unwrap();
-    let hal_module = vm::Module::hal(&instance, &device).unwrap();
-    let bytecode_module = vm::Module::bytecode(&instance, vmfb).unwrap();
-    let context = vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
-    let function = context.resolve_function("arithmetic.simple_mul").unwrap();
+    let runtime = Runtime::new(Driver::LocalSync).unwrap();
+    let program = runtime.load_vmfb(vmfb).unwrap();
 
-    let input = hal::BufferView::<f32>::from_host(
-        &device,
-        &[4],
-        hal::Encoding::DenseRowMajor,
-        &[1.0, 2.0, 3.0, 4.0]
-    ).unwrap();
-    let mut inputs = vm::List::<vm::Undefined>::new(2, &instance).unwrap();
-    inputs.push_ref(&input.to_ref(&instance).unwrap()).unwrap();
-    inputs.push_ref(&input.to_ref(&instance).unwrap()).unwrap();
-    let mut outputs = vm::List::<vm::Undefined>::new(1, &instance).unwrap();
-    function.invoke(&inputs, &mut outputs).unwrap();
-    outputs
-        .get_ref::<hal::BufferView<f32>>(0)
-        .unwrap()
-        .to_buffer_view()
-        .unwrap()
-        .read_to_vec(&device)
-        .unwrap()
+    let lhs = runtime.buffer_view(&[4], &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    let rhs = runtime.buffer_view(&[4], &[4.0, 3.0, 2.0, 1.0]).unwrap();
+
+    let function = program.function("arithmetic.simple_mul").unwrap();
+    let outputs = function.invoke([&lhs, &rhs]).unwrap();
+    let output: BufferView<f32> = outputs.into_iter().next().unwrap().try_into().unwrap();
+    output.read().unwrap()
 }
 ```
 More examples [here](https://github.com/gmmyung/eerie/tree/main/examples)
@@ -103,20 +85,23 @@ The crate is divided into two sections: compiler and runtime. You can enable eac
 ### Runtime
 Eerie builds the IREE runtime from source during compilation. CMake, Clang are required.
 
-`runtime::vm::Instance::global()` returns a retained handle to the process-wide VM
-instance; it does not create an independent IREE VM instance. IREE expects VM
-instances to be reused across contexts, and HAL type registration uses
-process-global adapter state.
-The root VM instance is retained for the lifetime of the process or embedded
-program. Dropping an `Instance` releases the returned handle, but does not tear
-down the shared runtime root.
-
-Typed tensor-shaped runtime values are represented by `runtime::hal::BufferView<T>`.
-Function calls use VM `List` values directly: convert input buffer views with
-`ToRef`, call `runtime::vm::Function::invoke`, then extract output
-`Ref<BufferView<T>>` values from the output list.
+The runtime API is `runtime::Runtime -> Program -> Function`. It creates the
+shared VM instance, HAL device, modules, and VM context for you and serializes
+VM/HAL lifecycle setup around IREE's low-level initialization path. The shared
+VM instance root is retained for the lifetime of the process or embedded
+program because IREE HAL type registration uses process-global adapter state.
+Typed tensor-shaped runtime values are represented by `runtime::BufferView<T>`.
+The low-level VM/HAL assembly APIs are intentionally crate-private; users create
+input buffers through `Runtime::buffer_view`, resolve functions through
+`Program::function`, invoke with `Function::invoke`, convert returned `Value`s
+into typed `BufferView<T>` handles, and read outputs with `BufferView::read`.
 Supported `BufferView<T>` element types are `bool` (IREE Bool8), signed and
 unsigned 8/16/32/64-bit integers, `f16`, `bf16`, `f32`, and `f64`.
+
+Runtime driver selection uses `runtime::Driver`, not raw driver strings.
+`Driver::LocalSync` is always available. `Driver::LocalTask` is available with
+`std`, `Driver::Metal` is available on macOS with `std`, and `Driver::Cuda` is
+available with `std` and the `cuda` feature.
 
 #### MacOS
 Install XCode and MacOS SDKs.

--- a/examples/resnet.rs
+++ b/examples/resnet.rs
@@ -2,8 +2,6 @@
 use std::{path::PathBuf, str::FromStr};
 
 #[cfg(all(feature = "compiler", feature = "runtime"))]
-use eerie::runtime::vm::ToRef;
-#[cfg(all(feature = "compiler", feature = "runtime"))]
 fn compile_mlir(data: &[u8]) -> Vec<u8> {
     use eerie::compiler;
     let target_backend =
@@ -62,54 +60,27 @@ fn load_image_bin(path: PathBuf) -> Vec<f32> {
 }
 #[cfg(all(feature = "compiler", feature = "runtime"))]
 fn run(vmfb: &[u8], image_bin: &[f32]) -> Vec<f32> {
-    use eerie::runtime;
-    let instance = runtime::vm::Instance::global().unwrap();
-    let registry = runtime::hal::DriverRegistry::with_available_drivers()
-        .expect("failed to create HAL driver registry");
-    let hal_driver = std::env::var("EERIE_HAL_DRIVER").unwrap_or_else(|_| "local-task".to_string());
-    let driver = registry
-        .create_driver(&hal_driver)
-        .unwrap_or_else(|err| panic!("failed to create HAL driver {hal_driver}: {err:?}"));
-    let device = driver
-        .create_default_device()
-        .unwrap_or_else(|err| panic!("failed to create default device for {hal_driver}: {err:?}"));
-    let hal_module =
-        runtime::vm::Module::hal(&instance, &device).expect("failed to create HAL VM module");
-    let bytecode_module =
-        runtime::vm::Module::bytecode(&instance, vmfb).expect("failed to load bytecode module");
-    let context = runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module])
-        .expect("failed to create VM context");
-    let function = context
-        .resolve_function("module.serving_default")
+    use eerie::runtime::{BufferView, Driver, Runtime};
+
+    let runtime = Runtime::new(Driver::LocalTask)
+        .unwrap_or_else(|err| panic!("failed to create local-task runtime: {err:?}"));
+    let program = runtime.load_vmfb(vmfb).expect("failed to load VMFB");
+    let input = runtime
+        .buffer_view(&[1, 3, 224, 224], image_bin)
+        .expect("failed to upload input image tensor");
+    let function = program
+        .function("module.serving_default")
         .expect("failed to resolve module.serving_default");
-    let input = runtime::hal::BufferView::<f32>::from_host(
-        &device,
-        &[1, 3, 224, 224],
-        runtime::hal::Encoding::DenseRowMajor,
-        image_bin,
-    )
-    .expect("failed to upload input image tensor");
-    let mut inputs = runtime::vm::List::<runtime::vm::Undefined>::new(1, &instance)
-        .expect("failed to create VM input list");
-    inputs
-        .push_ref(
-            &input
-                .to_ref(&instance)
-                .expect("failed to retain input buffer view"),
-        )
-        .expect("failed to push input buffer view");
-    let mut outputs = runtime::vm::List::<runtime::vm::Undefined>::new(1, &instance)
-        .expect("failed to create VM output list");
-    function
-        .invoke(&inputs, &mut outputs)
+    let outputs = function
+        .invoke([&input])
         .expect("failed to invoke module.serving_default");
-    outputs
-        .get_ref::<runtime::hal::BufferView<f32>>(0)
-        .expect("missing output buffer view")
-        .to_buffer_view()
-        .expect("failed to retain output buffer view")
-        .read_to_vec(&device)
-        .expect("failed to read output tensor to host")
+    let output: BufferView<f32> = outputs
+        .into_iter()
+        .next()
+        .expect("missing output tensor")
+        .try_into()
+        .expect("unexpected output tensor type");
+    output.read().expect("failed to read output tensor to host")
 }
 #[cfg(all(feature = "compiler", feature = "runtime"))]
 fn main() {

--- a/examples/resnet.rs
+++ b/examples/resnet.rs
@@ -2,10 +2,62 @@
 use std::{path::PathBuf, str::FromStr};
 
 #[cfg(all(feature = "compiler", feature = "runtime"))]
-fn compile_mlir(data: &[u8]) -> Vec<u8> {
+fn target_backend() -> String {
+    std::env::var("EERIE_HAL_TARGET_BACKEND").unwrap_or_else(|_| "llvm-cpu".to_string())
+}
+
+#[cfg(all(feature = "compiler", feature = "runtime"))]
+fn parse_runtime_driver(name: &str) -> eerie::runtime::Driver {
+    use eerie::runtime::Driver;
+
+    match name {
+        "local-sync" => Driver::LocalSync,
+        "local-task" => Driver::LocalTask,
+        "metal" => {
+            #[cfg(target_os = "macos")]
+            {
+                Driver::Metal
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                panic!("EERIE_HAL_DRIVER=metal requires macOS")
+            }
+        }
+        "cuda" => {
+            #[cfg(feature = "cuda")]
+            {
+                Driver::Cuda
+            }
+            #[cfg(not(feature = "cuda"))]
+            {
+                panic!("EERIE_HAL_DRIVER=cuda requires the cuda feature")
+            }
+        }
+        other => panic!(
+            "unsupported EERIE_HAL_DRIVER={other}; expected local-sync, local-task, metal, or cuda"
+        ),
+    }
+}
+
+#[cfg(all(feature = "compiler", feature = "runtime"))]
+fn runtime_driver_for_backend(target_backend: &str) -> eerie::runtime::Driver {
+    if let Ok(driver) = std::env::var("EERIE_HAL_DRIVER") {
+        return parse_runtime_driver(&driver);
+    }
+
+    match target_backend {
+        "llvm-cpu" | "vmvx" => parse_runtime_driver("local-task"),
+        "metal-spirv" => parse_runtime_driver("metal"),
+        "cuda" => parse_runtime_driver("cuda"),
+        other => panic!(
+            "cannot infer runtime driver for EERIE_HAL_TARGET_BACKEND={other}; set EERIE_HAL_DRIVER"
+        ),
+    }
+}
+
+#[cfg(all(feature = "compiler", feature = "runtime"))]
+fn compile_mlir(data: &[u8], target_backend: &str) -> Vec<u8> {
     use eerie::compiler;
-    let target_backend =
-        std::env::var("EERIE_HAL_TARGET_BACKEND").unwrap_or_else(|_| "llvm-cpu".to_string());
     let compiler = compiler::Compiler::new().expect("failed to initialize IREE compiler");
     let mut compiler_session = compiler.create_session();
     compiler_session
@@ -59,11 +111,11 @@ fn load_image_bin(path: PathBuf) -> Vec<f32> {
     image_bin
 }
 #[cfg(all(feature = "compiler", feature = "runtime"))]
-fn run(vmfb: &[u8], image_bin: &[f32]) -> Vec<f32> {
-    use eerie::runtime::{BufferView, Driver, Runtime};
+fn run(vmfb: &[u8], image_bin: &[f32], driver: eerie::runtime::Driver) -> Vec<f32> {
+    use eerie::runtime::{BufferView, Runtime};
 
-    let runtime = Runtime::new(Driver::LocalTask)
-        .unwrap_or_else(|err| panic!("failed to create local-task runtime: {err:?}"));
+    let runtime =
+        Runtime::new(driver).unwrap_or_else(|err| panic!("failed to create runtime: {err:?}"));
     let program = runtime.load_vmfb(vmfb).expect("failed to load VMFB");
     let input = runtime
         .buffer_view(&[1, 3, 224, 224], image_bin)
@@ -89,14 +141,16 @@ fn main() {
     let start = std::time::Instant::now();
     let mlir_bytecode =
         std::fs::read("examples/resnet50.mlir").expect("missing examples/resnet50.mlir");
-    let compiled_bytecode = compile_mlir(&mlir_bytecode);
+    let target_backend = target_backend();
+    let runtime_driver = runtime_driver_for_backend(&target_backend);
+    let compiled_bytecode = compile_mlir(&mlir_bytecode, &target_backend);
 
     println!("Compiled in {} ms", start.elapsed().as_millis());
 
     // timer for run
     let start = std::time::Instant::now();
     let image_bin = load_image_bin(PathBuf::from_str("examples/cat.bin").unwrap());
-    let output = run(&compiled_bytecode, &image_bin);
+    let output = run(&compiled_bytecode, &image_bin, runtime_driver);
     println!("Run in {} ms", start.elapsed().as_millis());
     let max_idx = output
         .iter()

--- a/examples/resnet.rs
+++ b/examples/resnet.rs
@@ -63,7 +63,7 @@ fn load_image_bin(path: PathBuf) -> Vec<f32> {
 #[cfg(all(feature = "compiler", feature = "runtime"))]
 fn run(vmfb: &[u8], image_bin: &[f32]) -> Vec<f32> {
     use eerie::runtime;
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let registry = runtime::hal::DriverRegistry::with_available_drivers()
         .expect("failed to create HAL driver registry");
     let hal_driver = std::env::var("EERIE_HAL_DRIVER").unwrap_or_else(|_| "local-task".to_string());

--- a/src/runtime/base.rs
+++ b/src/runtime/base.rs
@@ -1,36 +1,71 @@
-use core::{alloc::Layout, ffi::c_void, fmt::Display, marker::PhantomData};
 extern crate alloc;
+use alloc::rc::Rc;
+use core::{alloc::Layout, ffi::c_void, fmt::Display, marker::PhantomData};
 use eerie_sys::runtime as sys;
 use log::trace;
+#[cfg(feature = "std")]
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-/// A wrapper for a mutable byte span
-pub struct ByteSpan<'a> {
-    pub(crate) ctx: sys::iree_byte_span_t,
-    marker: PhantomData<&'a mut [u8]>,
+#[cfg(feature = "std")]
+static RUNTIME_LOCK: RwLock<()> = RwLock::new(());
+
+pub(crate) type NotSendSync = PhantomData<Rc<()>>;
+
+pub(crate) const fn not_send_sync() -> NotSendSync {
+    PhantomData
 }
 
-impl<'a> From<&'a mut [u8]> for ByteSpan<'a> {
-    fn from(slice: &'a mut [u8]) -> Self {
-        let byte_span = sys::iree_byte_span_t {
-            data: slice.as_ptr() as *mut u8,
-            data_length: slice.len(),
-        };
-        Self {
-            ctx: byte_span,
-            marker: PhantomData,
+#[cfg(feature = "std")]
+pub(crate) struct RuntimeLifecycleGuard {
+    _guard: RwLockWriteGuard<'static, ()>,
+}
+
+#[cfg(feature = "std")]
+pub(crate) struct RuntimeInvocationGuard {
+    _guard: RwLockReadGuard<'static, ()>,
+}
+
+#[cfg(not(feature = "std"))]
+pub(crate) struct RuntimeLifecycleGuard;
+
+#[cfg(not(feature = "std"))]
+pub(crate) struct RuntimeInvocationGuard;
+
+pub(crate) fn runtime_lifecycle_guard() -> RuntimeLifecycleGuard {
+    #[cfg(feature = "std")]
+    {
+        RuntimeLifecycleGuard {
+            _guard: RUNTIME_LOCK
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
         }
+    }
+
+    #[cfg(not(feature = "std"))]
+    {
+        RuntimeLifecycleGuard
     }
 }
 
-impl<'a> From<ByteSpan<'a>> for &'a mut [u8] {
-    fn from(byte_span: ByteSpan<'a>) -> Self {
-        unsafe { core::slice::from_raw_parts_mut(byte_span.ctx.data, byte_span.ctx.data_length) }
+pub(crate) fn runtime_invocation_guard() -> RuntimeInvocationGuard {
+    #[cfg(feature = "std")]
+    {
+        RuntimeInvocationGuard {
+            _guard: RUNTIME_LOCK
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    {
+        RuntimeInvocationGuard
     }
 }
 
 /// A wrapper for a constant byte span
-pub struct ConstByteSpan<'a> {
-    pub ctx: sys::iree_const_byte_span_t,
+pub(crate) struct ConstByteSpan<'a> {
+    pub(crate) ctx: sys::iree_const_byte_span_t,
     marker: PhantomData<&'a [u8]>,
 }
 
@@ -47,26 +82,18 @@ impl<'a> From<&'a [u8]> for ConstByteSpan<'a> {
     }
 }
 
-impl<'a> From<ConstByteSpan<'a>> for &'a [u8] {
-    fn from(byte_span: ConstByteSpan<'a>) -> Self {
-        unsafe { core::slice::from_raw_parts(byte_span.ctx.data, byte_span.ctx.data_length) }
-    }
-}
-
 /// A wrapper for a string view
-pub struct StringView<'a> {
-    pub ctx: sys::iree_string_view_t,
+pub(crate) struct StringView<'a> {
+    pub(crate) ctx: sys::iree_string_view_t,
     marker: PhantomData<&'a str>,
 }
 
 impl Display for StringView<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", unsafe {
-            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
-                self.ctx.data as *const u8,
-                self.ctx.size,
-            ))
-        })
+        let bytes =
+            unsafe { core::slice::from_raw_parts(self.ctx.data as *const u8, self.ctx.size) };
+        let value = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
+        write!(f, "{value}")
     }
 }
 
@@ -83,23 +110,12 @@ impl<'a> From<&'a str> for StringView<'a> {
     }
 }
 
-impl<'a> From<StringView<'a>> for &'a str {
-    fn from(string_view: StringView<'a>) -> Self {
-        unsafe {
-            core::str::from_utf8_unchecked(core::slice::from_raw_parts(
-                string_view.ctx.data as *const u8,
-                string_view.ctx.size,
-            ))
-        }
-    }
-}
-
 pub(crate) struct Allocator {
     pub(crate) ctx: sys::iree_allocator_t,
 }
 
 impl Allocator {
-    pub fn get_global() -> Self {
+    pub(crate) fn get_global() -> Self {
         let allocator = sys::iree_allocator_t {
             self_: core::ptr::null_mut(),
             ctl: Some(rust_allocator_ctl),
@@ -107,7 +123,7 @@ impl Allocator {
         Self { ctx: allocator }
     }
 
-    pub fn null_allocator() -> Self {
+    pub(crate) fn null_allocator() -> Self {
         let allocator = sys::iree_allocator_t {
             self_: core::ptr::null_mut(),
             ctl: None,
@@ -236,7 +252,7 @@ unsafe extern "C" fn rust_allocator_ctl(
 }
 
 /// IREE runtime status
-pub struct Status {
+pub(crate) struct Status {
     ctx: sys::iree_status_t,
 }
 
@@ -256,21 +272,11 @@ impl Status {
         self.ctx as usize == 0
     }
 
-    /// Converts from `Status` to `Result<(), StatusError>`.
-    pub fn to_result(self) -> Result<(), StatusError> {
+    pub(crate) fn into_result(self) -> Result<(), StatusError> {
         if self.is_ok() {
             Ok(())
         } else {
             Err(StatusError { status: self })
-        }
-    }
-
-    /// Returns a new status that is |base_status| if not OK and otherwise returns
-    /// |new_status|. This allows for chaining failure handling code that may also
-    /// return statuses.
-    pub fn chain(self, other: Self) -> Self {
-        Self {
-            ctx: unsafe { sys::iree_status_join(self.ctx, other.ctx) },
         }
     }
 }
@@ -320,7 +326,7 @@ impl Drop for Status {
 }
 
 /// IREE runtime status error
-pub enum StatusErrorKind {
+pub(crate) enum StatusErrorKind {
     Cancelled,
     Unknown,
     InvalidArgument,

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -1,25 +1,24 @@
 extern crate alloc;
-use super::base;
 use alloc::string::String;
+
+pub use super::base::StatusError;
 
 #[derive(Debug)]
 pub enum RuntimeError {
-    StatusError(base::StatusError),
-    InstanceMismatch(String),
+    Status(StatusError),
     InvalidArgument(String),
 }
 
-impl From<base::StatusError> for RuntimeError {
-    fn from(err: base::StatusError) -> Self {
-        RuntimeError::StatusError(err)
+impl From<StatusError> for RuntimeError {
+    fn from(err: StatusError) -> Self {
+        RuntimeError::Status(err)
     }
 }
 
 impl core::fmt::Display for RuntimeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            RuntimeError::StatusError(err) => write!(f, "IREE runtime error: {}", err),
-            RuntimeError::InstanceMismatch(msg) => write!(f, "IREE runtime error: {}", msg),
+            RuntimeError::Status(err) => write!(f, "IREE runtime error: {}", err),
             RuntimeError::InvalidArgument(msg) => write!(f, "IREE runtime error: {}", msg),
         }
     }
@@ -28,8 +27,8 @@ impl core::fmt::Display for RuntimeError {
 impl core::error::Error for RuntimeError {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
-            RuntimeError::StatusError(err) => Some(err),
-            RuntimeError::InstanceMismatch(_) | RuntimeError::InvalidArgument(_) => None,
+            RuntimeError::Status(err) => Some(err),
+            RuntimeError::InvalidArgument(_) => None,
         }
     }
 }

--- a/src/runtime/hal.rs
+++ b/src/runtime/hal.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::{borrow::Cow, format, string::String, vec::Vec};
+use alloc::{borrow::Cow, format, vec::Vec};
 use core::{
     fmt::{Debug, Formatter},
     marker::PhantomData,
@@ -16,15 +16,20 @@ use super::{
 };
 
 mod private {
-    pub trait Sealed {}
-}
+    use super::{Cow, RuntimeError, Vec};
 
-fn string_view_to_string(value: sys::iree_string_view_t) -> String {
-    if value.data.is_null() || value.size == 0 {
-        return String::new();
+    pub trait Element: Copy {
+        const IS_RAW_STORAGE_COMPATIBLE: bool;
+        const IREE_ELEMENT_TYPE: u32;
+
+        fn element_size() -> usize {
+            core::mem::size_of::<Self>()
+        }
+
+        fn as_bytes(data: &[Self]) -> Cow<'_, [u8]>;
+
+        fn decode_slice(bytes: &[u8]) -> Result<Vec<Self>, RuntimeError>;
     }
-    let bytes = unsafe { core::slice::from_raw_parts(value.data as *const u8, value.size) };
-    String::from_utf8_lossy(bytes).into_owned()
 }
 
 fn infinite_timeout() -> sys::iree_timeout_t {
@@ -35,29 +40,33 @@ fn infinite_timeout() -> sys::iree_timeout_t {
 }
 
 /// A HAL driver registry populated with the drivers linked into this binary.
-pub struct DriverRegistry {
+pub(crate) struct DriverRegistry {
     pub(crate) ctx: *mut sys::iree_hal_driver_registry_t,
     host_allocator: base::Allocator,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl DriverRegistry {
     /// Creates a driver registry and registers all available IREE HAL drivers.
-    pub fn with_available_drivers() -> Result<Self, RuntimeError> {
+    pub(crate) fn with_available_drivers() -> Result<Self, RuntimeError> {
+        let _guard = base::runtime_lifecycle_guard();
         let host_allocator = base::Allocator::get_global();
         let mut ctx = core::ptr::null_mut();
         base::Status::from_raw(unsafe {
             sys::iree_hal_driver_registry_allocate(host_allocator.ctx, &mut ctx)
         })
-        .to_result()?;
+        .into_result()?;
         base::Status::from_raw(unsafe { sys::iree_hal_register_all_available_drivers(ctx) })
-            .to_result()?;
+            .into_result()?;
         Ok(Self {
             ctx,
             host_allocator,
+            _not_send_sync: base::not_send_sync(),
         })
     }
 
-    pub fn create_driver(&self, name: &str) -> Result<Driver, RuntimeError> {
+    pub(crate) fn create_driver(&self, name: &str) -> Result<Driver, RuntimeError> {
+        let _guard = base::runtime_lifecycle_guard();
         let mut ctx = core::ptr::null_mut();
         base::Status::from_raw(unsafe {
             sys::iree_hal_driver_registry_try_create(
@@ -67,16 +76,18 @@ impl DriverRegistry {
                 &mut ctx,
             )
         })
-        .to_result()?;
+        .into_result()?;
         Ok(Driver {
             ctx,
             host_allocator: base::Allocator::get_global(),
+            _not_send_sync: base::not_send_sync(),
         })
     }
 }
 
 impl Drop for DriverRegistry {
     fn drop(&mut self) {
+        let _guard = base::runtime_lifecycle_guard();
         unsafe {
             sys::iree_hal_driver_registry_free(self.ctx);
         }
@@ -84,105 +95,26 @@ impl Drop for DriverRegistry {
 }
 
 /// A HAL driver.
-pub struct Driver {
+pub(crate) struct Driver {
     pub(crate) ctx: *mut sys::iree_hal_driver_t,
     host_allocator: base::Allocator,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl Driver {
-    /// Queries devices currently available through this driver.
-    pub fn available_devices(&self) -> Result<Vec<DeviceInfo>, RuntimeError> {
-        let mut count = 0usize;
-        let mut infos = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_driver_query_available_devices(
-                self.ctx,
-                self.host_allocator.ctx,
-                &mut count,
-                &mut infos,
-            )
-        })
-        .to_result()?;
-
-        if infos.is_null() || count == 0 {
-            return Ok(Vec::new());
-        }
-
-        let result = unsafe { core::slice::from_raw_parts(infos, count) }
-            .iter()
-            .enumerate()
-            .map(|(ordinal, info)| DeviceInfo {
-                ordinal,
-                id: info.device_id,
-                path: string_view_to_string(info.path),
-                name: string_view_to_string(info.name),
-            })
-            .collect();
-
-        unsafe {
-            sys::iree_allocator_free(self.host_allocator.ctx, infos as *mut core::ffi::c_void);
-        }
-
-        Ok(result)
-    }
-
     /// Creates the driver's default device.
-    pub fn create_default_device(&self) -> Result<Device, RuntimeError> {
+    pub(crate) fn create_default_device(&self) -> Result<Device, RuntimeError> {
+        let _guard = base::runtime_lifecycle_guard();
         let mut ctx = core::ptr::null_mut();
         base::Status::from_raw(unsafe {
             sys::iree_hal_driver_create_default_device(self.ctx, self.host_allocator.ctx, &mut ctx)
         })
-        .to_result()?;
-        Ok(Device { ctx })
-    }
-
-    /// Creates a device by ordinal as returned by `available_devices`.
-    pub fn create_device_by_ordinal(&self, ordinal: usize) -> Result<Device, RuntimeError> {
-        let mut ctx = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_driver_create_device_by_ordinal(
-                self.ctx,
-                ordinal,
-                0,
-                core::ptr::null(),
-                self.host_allocator.ctx,
-                &mut ctx,
-            )
+        .into_result()?;
+        Ok(Device {
+            ctx,
+            _not_send_sync: base::not_send_sync(),
         })
-        .to_result()?;
-        Ok(Device { ctx })
     }
-
-    /// Creates a device by driver-specific path.
-    pub fn create_device_by_path(
-        &self,
-        driver_name: &str,
-        path: &str,
-    ) -> Result<Device, RuntimeError> {
-        let mut ctx = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_driver_create_device_by_path(
-                self.ctx,
-                StringView::from(driver_name).ctx,
-                StringView::from(path).ctx,
-                0,
-                core::ptr::null(),
-                self.host_allocator.ctx,
-                &mut ctx,
-            )
-        })
-        .to_result()?;
-        Ok(Device { ctx })
-    }
-}
-
-/// A device enumerated by a HAL driver.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DeviceInfo {
-    pub ordinal: usize,
-    pub id: sys::iree_hal_device_id_t,
-    pub path: String,
-    pub name: String,
 }
 
 impl Clone for Driver {
@@ -193,12 +125,14 @@ impl Clone for Driver {
         Self {
             ctx: self.ctx,
             host_allocator: base::Allocator::get_global(),
+            _not_send_sync: base::not_send_sync(),
         }
     }
 }
 
 impl Drop for Driver {
     fn drop(&mut self) {
+        let _guard = base::runtime_lifecycle_guard();
         unsafe {
             sys::iree_hal_driver_release(self.ctx);
         }
@@ -206,222 +140,50 @@ impl Drop for Driver {
 }
 
 /// A HAL device.
-pub struct Device {
+pub(crate) struct Device {
     pub(crate) ctx: *mut sys::iree_hal_device_t,
+    _not_send_sync: base::NotSendSync,
 }
 
-impl Device {
-    pub fn id(&self) -> String {
-        string_view_to_string(unsafe { sys::iree_hal_device_id(self.ctx) })
-    }
-
-    pub fn query_i64(&self, category: &str, key: &str) -> Result<i64, RuntimeError> {
-        let mut value = 0;
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_device_query_i64(
-                self.ctx,
-                StringView::from(category).ctx,
-                StringView::from(key).ctx,
-                &mut value,
-            )
-        })
-        .to_result()?;
-        Ok(value)
-    }
-
-    pub fn capabilities(&self) -> Result<DeviceCapabilities, RuntimeError> {
-        let mut caps = sys::iree_hal_device_capabilities_t::default();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_device_query_capabilities(self.ctx, &mut caps)
-        })
-        .to_result()?;
-        Ok(DeviceCapabilities {
-            flags: caps.flags,
-            semaphore_export_types: caps.semaphore_export_types,
-            semaphore_import_types: caps.semaphore_import_types,
-            buffer_export_types: caps.buffer_export_types,
-            buffer_import_types: caps.buffer_import_types,
-            numa_node: caps.numa_node,
-            physical_device_uuid: caps
-                .has_physical_device_uuid
-                .then_some(caps.physical_device_uuid),
-            device_group_index: caps.has_device_group.then_some(caps.device_group_index),
-        })
-    }
-
-    pub fn trim(&self) -> Result<(), RuntimeError> {
-        base::Status::from_raw(unsafe { sys::iree_hal_device_trim(self.ctx) })
-            .to_result()
-            .map_err(Into::into)
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DeviceCapabilities {
-    pub flags: sys::iree_hal_device_capability_bits_t,
-    pub semaphore_export_types: sys::iree_hal_topology_handle_type_t,
-    pub semaphore_import_types: sys::iree_hal_topology_handle_type_t,
-    pub buffer_export_types: sys::iree_hal_topology_handle_type_t,
-    pub buffer_import_types: sys::iree_hal_topology_handle_type_t,
-    pub numa_node: u8,
-    pub physical_device_uuid: Option<[u8; 16]>,
-    pub device_group_index: Option<u32>,
-}
+impl Device {}
 
 impl Clone for Device {
     fn clone(&self) -> Self {
         unsafe {
             sys::iree_hal_device_retain(self.ctx);
         }
-        Self { ctx: self.ctx }
+        Self {
+            ctx: self.ctx,
+            _not_send_sync: base::not_send_sync(),
+        }
     }
 }
 
 impl Drop for Device {
     fn drop(&mut self) {
+        let _guard = base::runtime_lifecycle_guard();
         unsafe {
             sys::iree_hal_device_release(self.ctx);
         }
     }
 }
 
-/// A buffer view encoding.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Encoding {
-    Opaque,
-    DenseRowMajor,
-}
-
-impl From<Encoding> for sys::iree_hal_encoding_types_t {
-    fn from(encoding: Encoding) -> Self {
-        match encoding {
-            Encoding::Opaque => sys::iree_hal_encoding_types_t_IREE_HAL_ENCODING_TYPE_OPAQUE,
-            Encoding::DenseRowMajor => {
-                sys::iree_hal_encoding_types_t_IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR
-            }
-        }
-    }
-}
-
-impl From<sys::iree_hal_encoding_type_t> for Encoding {
-    fn from(encoding: sys::iree_hal_encoding_type_t) -> Self {
-        match encoding {
-            sys::iree_hal_encoding_types_t_IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR => {
-                Self::DenseRowMajor
-            }
-            _ => Self::Opaque,
-        }
-    }
-}
-
-/// A HAL buffer view element type.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ElementType {
-    None,
-    Opaque8,
-    Opaque16,
-    Opaque32,
-    Opaque64,
-    Bool8,
-    Int4,
-    Sint4,
-    Uint4,
-    Int8,
-    Sint8,
-    Uint8,
-    Int16,
-    Sint16,
-    Uint16,
-    Int32,
-    Sint32,
-    Uint32,
-    Int64,
-    Sint64,
-    Uint64,
-    Float16,
-    Float32,
-    Float64,
-    BFloat16,
-    ComplexFloat64,
-    ComplexFloat128,
-    Other(sys::iree_hal_element_type_t),
-}
-
-impl From<ElementType> for sys::iree_hal_element_type_t {
-    fn from(element_type: ElementType) -> Self {
-        match element_type {
-            ElementType::None => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_NONE,
-            ElementType::Opaque8 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_8,
-            ElementType::Opaque16 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_16,
-            ElementType::Opaque32 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_32,
-            ElementType::Opaque64 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_64,
-            ElementType::Bool8 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BOOL_8,
-            ElementType::Int4 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_4,
-            ElementType::Sint4 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_4,
-            ElementType::Uint4 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_4,
-            ElementType::Int8 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_8,
-            ElementType::Sint8 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_8,
-            ElementType::Uint8 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_8,
-            ElementType::Int16 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_16,
-            ElementType::Sint16 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_16,
-            ElementType::Uint16 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_16,
-            ElementType::Int32 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_32,
-            ElementType::Sint32 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_32,
-            ElementType::Uint32 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_32,
-            ElementType::Int64 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_64,
-            ElementType::Sint64 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_64,
-            ElementType::Uint64 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_64,
-            ElementType::Float16 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16,
-            ElementType::Float32 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_32,
-            ElementType::Float64 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_64,
-            ElementType::BFloat16 => sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16,
-            ElementType::ComplexFloat64 => {
-                sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_64
-            }
-            ElementType::ComplexFloat128 => {
-                sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_128
-            }
-            ElementType::Other(element_type) => element_type,
-        }
-    }
-}
-
-impl From<sys::iree_hal_element_type_t> for ElementType {
-    fn from(element_type: sys::iree_hal_element_type_t) -> Self {
-        match element_type {
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_NONE => Self::None,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_8 => Self::Opaque8,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_16 => Self::Opaque16,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_32 => Self::Opaque32,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_OPAQUE_64 => Self::Opaque64,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BOOL_8 => Self::Bool8,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_4 => Self::Int4,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_4 => Self::Sint4,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_4 => Self::Uint4,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_8 => Self::Int8,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_8 => Self::Sint8,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_8 => Self::Uint8,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_16 => Self::Int16,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_16 => Self::Sint16,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_16 => Self::Uint16,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_32 => Self::Int32,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_32 => Self::Sint32,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_32 => Self::Uint32,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_64 => Self::Int64,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_SINT_64 => Self::Sint64,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_64 => Self::Uint64,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16 => Self::Float16,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_32 => Self::Float32,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_64 => Self::Float64,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16 => Self::BFloat16,
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_64 => {
-                Self::ComplexFloat64
-            }
-            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_128 => {
-                Self::ComplexFloat128
-            }
-            _ => Self::Other(element_type),
-        }
+fn element_type_name(element_type: sys::iree_hal_element_type_t) -> &'static str {
+    match element_type {
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BOOL_8 => "bool",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_8 => "u8",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_16 => "u16",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_32 => "u32",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_64 => "u64",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_8 => "i8",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_16 => "i16",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_32 => "i32",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_64 => "i64",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16 => "f16",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_32 => "f32",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_64 => "f64",
+        sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16 => "bf16",
+        _ => "unsupported",
     }
 }
 
@@ -429,34 +191,13 @@ impl From<sys::iree_hal_element_type_t> for ElementType {
 ///
 /// This trait is sealed so the runtime wrapper can preserve Rust validity
 /// invariants while decoding raw device bytes.
-pub trait BufferElement: Copy + private::Sealed {
-    #[doc(hidden)]
-    const IS_RAW_STORAGE_COMPATIBLE: bool;
-
-    fn element_type() -> ElementType;
-
-    #[doc(hidden)]
-    fn element_size() -> usize {
-        core::mem::size_of::<Self>()
-    }
-
-    #[doc(hidden)]
-    fn as_bytes(data: &[Self]) -> Cow<'_, [u8]>;
-
-    #[doc(hidden)]
-    fn decode_slice(bytes: &[u8]) -> Result<Vec<Self>, RuntimeError>;
-}
+pub trait BufferElement: private::Element {}
 
 macro_rules! impl_buffer_element {
-    ($type:ty, $variant:ident) => {
-        impl private::Sealed for $type {}
-
-        impl BufferElement for $type {
+    ($type:ty, $element_type:expr) => {
+        impl private::Element for $type {
             const IS_RAW_STORAGE_COMPATIBLE: bool = true;
-
-            fn element_type() -> ElementType {
-                ElementType::$variant
-            }
+            const IREE_ELEMENT_TYPE: u32 = $element_type;
 
             fn as_bytes(data: &[Self]) -> Cow<'_, [u8]> {
                 let bytes = unsafe {
@@ -492,30 +233,63 @@ macro_rules! impl_buffer_element {
                 Ok(data)
             }
         }
+
+        impl BufferElement for $type {}
     };
 }
 
-impl_buffer_element!(u8, Uint8);
-impl_buffer_element!(u16, Uint16);
-impl_buffer_element!(u32, Uint32);
-impl_buffer_element!(u64, Uint64);
-impl_buffer_element!(i8, Int8);
-impl_buffer_element!(i16, Int16);
-impl_buffer_element!(i32, Int32);
-impl_buffer_element!(i64, Int64);
-impl_buffer_element!(f32, Float32);
-impl_buffer_element!(f64, Float64);
-impl_buffer_element!(f16, Float16);
-impl_buffer_element!(bf16, BFloat16);
+impl_buffer_element!(
+    u8,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_8
+);
+impl_buffer_element!(
+    u16,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_16
+);
+impl_buffer_element!(
+    u32,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_32
+);
+impl_buffer_element!(
+    u64,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_64
+);
+impl_buffer_element!(
+    i8,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_8
+);
+impl_buffer_element!(
+    i16,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_16
+);
+impl_buffer_element!(
+    i32,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_32
+);
+impl_buffer_element!(
+    i64,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_64
+);
+impl_buffer_element!(
+    f32,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_32
+);
+impl_buffer_element!(
+    f64,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_64
+);
+impl_buffer_element!(
+    f16,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16
+);
+impl_buffer_element!(
+    bf16,
+    sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16
+);
 
-impl private::Sealed for bool {}
-
-impl BufferElement for bool {
+impl private::Element for bool {
     const IS_RAW_STORAGE_COMPATIBLE: bool = false;
-
-    fn element_type() -> ElementType {
-        ElementType::Bool8
-    }
+    const IREE_ELEMENT_TYPE: u32 = sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BOOL_8;
 
     fn as_bytes(data: &[Self]) -> Cow<'_, [u8]> {
         Cow::Owned(data.iter().map(|&value| u8::from(value)).collect())
@@ -536,144 +310,21 @@ impl BufferElement for bool {
     }
 }
 
-pub type MemoryType = sys::iree_hal_memory_type_t;
-pub type MemoryAccess = sys::iree_hal_memory_access_t;
-pub type BufferUsage = sys::iree_hal_buffer_usage_t;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct BufferParams {
-    pub memory_type: MemoryType,
-    pub access: MemoryAccess,
-    pub usage: BufferUsage,
-    pub queue_affinity: u64,
-    pub min_alignment: usize,
-}
-
-impl BufferParams {
-    pub fn device_local() -> Self {
-        Self {
-            memory_type: sys::iree_hal_memory_type_bits_t_IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-            access: sys::iree_hal_memory_access_bits_t_IREE_HAL_MEMORY_ACCESS_ALL as u16,
-            usage: sys::iree_hal_buffer_usage_bits_t_IREE_HAL_BUFFER_USAGE_DEFAULT,
-            queue_affinity: 0,
-            min_alignment: 0,
-        }
-    }
-
-    fn into_raw(self) -> sys::iree_hal_buffer_params_t {
-        sys::iree_hal_buffer_params_t {
-            usage: self.usage,
-            access: self.access,
-            type_: self.memory_type,
-            queue_affinity: self.queue_affinity,
-            min_alignment: self.min_alignment,
-        }
-    }
-}
-
-impl Default for BufferParams {
-    fn default() -> Self {
-        Self::device_local()
-    }
-}
-
-/// A first-class HAL buffer allocation or subspan.
-pub struct Buffer {
-    pub(crate) ctx: *mut sys::iree_hal_buffer_t,
-}
-
-impl Buffer {
-    pub fn allocate(
-        device: &Device,
-        byte_length: usize,
-        params: BufferParams,
-    ) -> Result<Self, RuntimeError> {
-        let mut ctx = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_allocator_allocate_buffer(
-                sys::iree_hal_device_allocator(device.ctx),
-                params.into_raw(),
-                byte_length,
-                &mut ctx,
-            )
-        })
-        .to_result()?;
-        Ok(Self { ctx })
-    }
-
-    pub(crate) unsafe fn from_raw_retained(ctx: *mut sys::iree_hal_buffer_t) -> Self {
-        unsafe {
-            sys::iree_hal_buffer_retain(ctx);
-        }
-        Self { ctx }
-    }
-
-    pub fn subspan(&self, byte_offset: usize, byte_length: usize) -> Result<Self, RuntimeError> {
-        let mut ctx = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_buffer_subspan(
-                self.ctx,
-                byte_offset,
-                byte_length,
-                base::Allocator::get_global().ctx,
-                &mut ctx,
-            )
-        })
-        .to_result()?;
-        Ok(Self { ctx })
-    }
-
-    pub fn byte_offset(&self) -> usize {
-        unsafe { sys::iree_hal_buffer_byte_offset(self.ctx) }
-    }
-
-    pub fn byte_length(&self) -> usize {
-        unsafe { sys::iree_hal_buffer_byte_length(self.ctx) }
-    }
-
-    pub fn allocation_size(&self) -> usize {
-        unsafe { sys::iree_hal_buffer_allocation_size(self.ctx) }
-    }
-
-    pub fn memory_type(&self) -> MemoryType {
-        unsafe { sys::iree_hal_buffer_memory_type(self.ctx) }
-    }
-
-    pub fn allowed_access(&self) -> MemoryAccess {
-        unsafe { sys::iree_hal_buffer_allowed_access(self.ctx) }
-    }
-
-    pub fn allowed_usage(&self) -> BufferUsage {
-        unsafe { sys::iree_hal_buffer_allowed_usage(self.ctx) }
-    }
-}
-
-impl Clone for Buffer {
-    fn clone(&self) -> Self {
-        unsafe { Self::from_raw_retained(self.ctx) }
-    }
-}
-
-impl Drop for Buffer {
-    fn drop(&mut self) {
-        unsafe {
-            sys::iree_hal_buffer_release(self.ctx);
-        }
-    }
-}
+impl BufferElement for bool {}
 
 /// A shaped and typed view into a HAL buffer.
 pub struct BufferView<T: BufferElement> {
     pub(crate) ctx: *mut sys::iree_hal_buffer_view_t,
+    device: Device,
     marker: PhantomData<T>,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl<T: BufferElement> BufferView<T> {
     /// Allocates a buffer on `device` and copies `data` into it.
-    pub fn from_host(
+    pub(crate) fn from_host(
         device: &Device,
         shape: &[usize],
-        encoding: Encoding,
         data: &[T],
     ) -> Result<Self, RuntimeError> {
         let expected_len = shape.iter().try_fold(1usize, |product, dim| {
@@ -704,11 +355,11 @@ impl<T: BufferElement> BufferView<T> {
                 sys::iree_hal_device_allocator(device.ctx),
                 shape.len(),
                 shape.as_ptr(),
-                T::element_type().into(),
-                encoding.into(),
+                T::IREE_ELEMENT_TYPE as sys::iree_hal_element_type_t,
+                sys::iree_hal_encoding_types_t_IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
                 sys::iree_hal_buffer_params_t {
                     usage: sys::iree_hal_buffer_usage_bits_t_IREE_HAL_BUFFER_USAGE_DEFAULT,
-                    access: 0,
+                    access: sys::iree_hal_memory_access_bits_t_IREE_HAL_MEMORY_ACCESS_ALL as _,
                     type_: sys::iree_hal_memory_type_bits_t_IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
                     queue_affinity: 0,
                     min_alignment: 0,
@@ -717,170 +368,59 @@ impl<T: BufferElement> BufferView<T> {
                 &mut ctx,
             )
         })
-        .to_result()?;
+        .into_result()?;
         Ok(Self {
             ctx,
+            device: device.clone(),
             marker: PhantomData,
+            _not_send_sync: base::not_send_sync(),
         })
     }
 
-    pub(crate) unsafe fn from_raw_retained(ctx: *mut sys::iree_hal_buffer_view_t) -> Self {
+    pub(crate) unsafe fn from_raw_retained(
+        ctx: *mut sys::iree_hal_buffer_view_t,
+        device: &Device,
+    ) -> Self {
         unsafe {
             sys::iree_hal_buffer_view_retain(ctx);
         }
         Self {
             ctx,
+            device: device.clone(),
             marker: PhantomData,
+            _not_send_sync: base::not_send_sync(),
         }
     }
 
-    pub(crate) fn buffer(&self) -> *mut sys::iree_hal_buffer_t {
+    pub(crate) fn raw_buffer(&self) -> *mut sys::iree_hal_buffer_t {
         unsafe { sys::iree_hal_buffer_view_buffer(self.ctx) }
     }
 
-    pub fn raw_buffer(&self) -> Buffer {
-        unsafe { Buffer::from_raw_retained(self.buffer()) }
-    }
-
-    pub fn from_buffer(
-        buffer: &Buffer,
-        shape: &[usize],
-        encoding: Encoding,
-    ) -> Result<Self, RuntimeError> {
-        let expected_byte_length = shape.iter().try_fold(T::element_size(), |product, dim| {
-            product.checked_mul(*dim).ok_or_else(|| {
-                RuntimeError::InvalidArgument(format!(
-                    "buffer shape {:?} overflows usize byte count",
-                    shape
-                ))
-            })
-        })?;
-        if expected_byte_length > buffer.byte_length() {
-            return Err(RuntimeError::InvalidArgument(format!(
-                "buffer view requires {} bytes, buffer has {} bytes",
-                expected_byte_length,
-                buffer.byte_length()
-            )));
-        }
-        let mut ctx = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_buffer_view_create(
-                buffer.ctx,
-                shape.len(),
-                shape.as_ptr(),
-                T::element_type().into(),
-                encoding.into(),
-                base::Allocator::get_global().ctx,
-                &mut ctx,
-            )
-        })
-        .to_result()?;
-        Ok(Self {
-            ctx,
-            marker: PhantomData,
-        })
-    }
-
-    pub fn byte_length(&self) -> usize {
+    fn byte_length(&self) -> usize {
         unsafe { sys::iree_hal_buffer_view_byte_length(self.ctx) }
     }
 
-    pub fn rank(&self) -> usize {
+    fn rank(&self) -> usize {
         unsafe { sys::iree_hal_buffer_view_shape_rank(self.ctx) }
     }
 
     pub fn shape(&self) -> Vec<usize> {
         let rank = self.rank();
+        if rank == 0 {
+            return Vec::new();
+        }
         let dims = unsafe { sys::iree_hal_buffer_view_shape_dims(self.ctx) };
         unsafe { core::slice::from_raw_parts(dims, rank) }.to_vec()
     }
 
-    pub fn dim(&self, index: usize) -> usize {
-        unsafe { sys::iree_hal_buffer_view_shape_dim(self.ctx, index) }
-    }
-
-    pub fn element_count(&self) -> usize {
-        unsafe { sys::iree_hal_buffer_view_element_count(self.ctx) }
-    }
-
-    pub fn element_size(&self) -> usize {
-        unsafe { sys::iree_hal_buffer_view_element_size(self.ctx) }
-    }
-
-    pub fn element_type(&self) -> ElementType {
-        unsafe { sys::iree_hal_buffer_view_element_type(self.ctx) }.into()
-    }
-
-    pub fn encoding(&self) -> Encoding {
-        unsafe { sys::iree_hal_buffer_view_encoding_type(self.ctx) }.into()
-    }
-
-    /// Synchronously overwrites the buffer contents from host memory.
-    pub fn write_from_slice(&self, device: &Device, data: &[T]) -> Result<(), RuntimeError> {
-        if self.element_type() != T::element_type() {
-            return Err(RuntimeError::InvalidArgument(format!(
-                "buffer element type mismatch: expected {:?}, got {:?}",
-                T::element_type(),
-                self.element_type()
-            )));
-        }
-        if data.len() != self.element_count() {
-            return Err(RuntimeError::InvalidArgument(format!(
-                "buffer requires {} elements, got {}",
-                self.element_count(),
-                data.len()
-            )));
-        }
-        let encoded = T::as_bytes(data);
-        let byte_length = encoded.len();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_device_transfer_h2d(
-                device.ctx,
-                encoded.as_ref().as_ptr() as *const core::ffi::c_void,
-                self.buffer(),
-                0,
-                byte_length,
-                sys::iree_hal_transfer_buffer_flag_bits_t_IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
-                infinite_timeout(),
-            )
-        })
-        .to_result()
-        .map_err(Into::into)
-    }
-
-    /// Synchronously copies this buffer view into another buffer view.
-    pub fn copy_to(&self, device: &Device, target: &BufferView<T>) -> Result<(), RuntimeError> {
-        if self.byte_length() != target.byte_length() {
-            return Err(RuntimeError::InvalidArgument(format!(
-                "source byte length {} does not match target byte length {}",
-                self.byte_length(),
-                target.byte_length()
-            )));
-        }
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_device_transfer_d2d(
-                device.ctx,
-                self.buffer(),
-                0,
-                target.buffer(),
-                0,
-                self.byte_length(),
-                sys::iree_hal_transfer_buffer_flag_bits_t_IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
-                infinite_timeout(),
-            )
-        })
-        .to_result()
-        .map_err(Into::into)
-    }
-
     /// Synchronously reads the buffer view contents back to host memory.
-    pub fn read_to_vec(&self, device: &Device) -> Result<Vec<T>, RuntimeError> {
-        let element_type = self.element_type();
-        if element_type != T::element_type() {
+    pub fn read(&self) -> Result<Vec<T>, RuntimeError> {
+        let element_type = unsafe { sys::iree_hal_buffer_view_element_type(self.ctx) };
+        if element_type != T::IREE_ELEMENT_TYPE as sys::iree_hal_element_type_t {
             return Err(RuntimeError::InvalidArgument(format!(
-                "buffer element type mismatch: expected {:?}, got {:?}",
-                T::element_type(),
-                element_type
+                "buffer element type mismatch: expected {}, got {}",
+                element_type_name(T::IREE_ELEMENT_TYPE as sys::iree_hal_element_type_t),
+                element_type_name(element_type)
             )));
         }
         let byte_length = self.byte_length();
@@ -897,8 +437,8 @@ impl<T: BufferElement> BufferView<T> {
             let mut data = Vec::<T>::with_capacity(byte_length / element_size);
             base::Status::from_raw(unsafe {
                 sys::iree_hal_device_transfer_d2h(
-                    device.ctx,
-                    self.buffer(),
+                    self.device.ctx,
+                    self.raw_buffer(),
                     0,
                     data.as_mut_ptr() as *mut core::ffi::c_void,
                     byte_length,
@@ -906,7 +446,7 @@ impl<T: BufferElement> BufferView<T> {
                     infinite_timeout(),
                 )
             })
-            .to_result()?;
+            .into_result()?;
             unsafe {
                 data.set_len(byte_length / element_size);
             }
@@ -916,8 +456,8 @@ impl<T: BufferElement> BufferView<T> {
         let mut bytes = Vec::<u8>::with_capacity(byte_length);
         base::Status::from_raw(unsafe {
             sys::iree_hal_device_transfer_d2h(
-                device.ctx,
-                self.buffer(),
+                self.device.ctx,
+                self.raw_buffer(),
                 0,
                 bytes.as_mut_ptr() as *mut core::ffi::c_void,
                 byte_length,
@@ -925,7 +465,7 @@ impl<T: BufferElement> BufferView<T> {
                 infinite_timeout(),
             )
         })
-        .to_result()?;
+        .into_result()?;
         unsafe {
             bytes.set_len(byte_length);
         }
@@ -935,7 +475,7 @@ impl<T: BufferElement> BufferView<T> {
 
 impl<T: BufferElement> Clone for BufferView<T> {
     fn clone(&self) -> Self {
-        unsafe { Self::from_raw_retained(self.ctx) }
+        unsafe { Self::from_raw_retained(self.ctx, &self.device) }
     }
 }
 
@@ -945,10 +485,10 @@ impl<T: BufferElement> Debug for BufferView<T> {
             let buf = &mut [b'\0' as core::ffi::c_char; 1024];
             let mut len: usize = 0;
             sys::iree_hal_buffer_view_format(self.ctx, 6, buf.len(), buf.as_mut_ptr(), &mut len);
-            alloc::string::String::from_utf8_lossy(
-                core::ffi::CStr::from_ptr(buf.as_ptr()).to_bytes(),
-            )
-            .into_owned()
+            let len = len.min(buf.len());
+            let bytes = core::slice::from_raw_parts(buf.as_ptr() as *const u8, len);
+            let bytes = bytes.strip_suffix(&[0]).unwrap_or(bytes);
+            alloc::string::String::from_utf8_lossy(bytes).into_owned()
         };
         f.write_str(&formatted)
     }
@@ -963,123 +503,149 @@ impl<T: BufferElement> Drop for BufferView<T> {
     }
 }
 
-/// A scoped host mapping of a HAL buffer view.
-pub struct BufferMapping<T: BufferElement> {
-    ctx: sys::iree_hal_buffer_mapping_t,
-    _buffer: BufferView<T>,
-    data: BufferMappingData<T>,
+/// A dynamically typed runtime buffer value.
+///
+/// `BufferView<T>` remains the typed tensor handle. `Value` is only used at the
+/// function invocation boundary, where IREE functions may accept and return
+/// different buffer element types.
+#[derive(Clone, Debug)]
+pub enum Value {
+    Bool(BufferView<bool>),
+    U8(BufferView<u8>),
+    U16(BufferView<u16>),
+    U32(BufferView<u32>),
+    U64(BufferView<u64>),
+    I8(BufferView<i8>),
+    I16(BufferView<i16>),
+    I32(BufferView<i32>),
+    I64(BufferView<i64>),
+    F16(BufferView<f16>),
+    F32(BufferView<f32>),
+    F64(BufferView<f64>),
+    Bf16(BufferView<bf16>),
 }
 
-enum BufferMappingData<T> {
-    Mapped { element_len: usize },
-    Owned(Vec<T>),
-}
-
-impl<T: BufferElement> BufferMapping<T> {
-    pub fn map_read(buffer_view: &BufferView<T>) -> Result<Self, RuntimeError> {
-        let element_type = buffer_view.element_type();
-        if element_type != T::element_type() {
-            return Err(RuntimeError::InvalidArgument(format!(
-                "buffer element type mismatch: expected {:?}, got {:?}",
-                T::element_type(),
-                element_type
-            )));
+impl Value {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Value::Bool(_) => "bool",
+            Value::U8(_) => "u8",
+            Value::U16(_) => "u16",
+            Value::U32(_) => "u32",
+            Value::U64(_) => "u64",
+            Value::I8(_) => "i8",
+            Value::I16(_) => "i16",
+            Value::I32(_) => "i32",
+            Value::I64(_) => "i64",
+            Value::F16(_) => "f16",
+            Value::F32(_) => "f32",
+            Value::F64(_) => "f64",
+            Value::Bf16(_) => "bf16",
         }
-        let buffer = buffer_view.clone();
-        let mut out = core::mem::MaybeUninit::<sys::iree_hal_buffer_mapping_t>::uninit();
-        base::Status::from_raw(unsafe {
-            sys::iree_hal_buffer_map_range(
-                buffer.buffer(),
-                sys::iree_hal_mapping_mode_bits_t_IREE_HAL_MAPPING_MODE_SCOPED,
-                sys::iree_hal_memory_access_bits_t_IREE_HAL_MEMORY_ACCESS_READ as u16,
-                0,
-                buffer.byte_length(),
-                out.as_mut_ptr(),
-            )
-        })
-        .to_result()?;
-        let mut ctx = unsafe { out.assume_init() };
-        let address = ctx.contents.data as usize;
-        if ctx.contents.data_length != 0 && address == 0 {
-            unsafe {
-                sys::iree_hal_buffer_unmap_range(&mut ctx);
-            }
-            return Err(RuntimeError::InvalidArgument(String::from(
-                "mapped buffer returned null data for a non-empty range",
-            )));
-        }
-        let data = if T::IS_RAW_STORAGE_COMPATIBLE {
-            let element_size = T::element_size();
-            debug_assert_ne!(element_size, 0);
-            if !ctx.contents.data_length.is_multiple_of(element_size) {
-                unsafe {
-                    sys::iree_hal_buffer_unmap_range(&mut ctx);
-                }
-                return Err(RuntimeError::InvalidArgument(format!(
-                    "mapped byte length {} is not divisible by element size {}",
-                    ctx.contents.data_length, element_size
-                )));
-            }
-            let align = core::mem::align_of::<T>();
-            if address != 0 && !address.is_multiple_of(align) {
-                unsafe {
-                    sys::iree_hal_buffer_unmap_range(&mut ctx);
-                }
-                return Err(RuntimeError::InvalidArgument(format!(
-                    "mapped buffer address 0x{address:x} is not aligned to {align}"
-                )));
-            }
-            BufferMappingData::Mapped {
-                element_len: ctx.contents.data_length / element_size,
-            }
-        } else {
-            let bytes = if ctx.contents.data_length == 0 {
-                &[]
-            } else {
-                unsafe {
-                    core::slice::from_raw_parts(
-                        ctx.contents.data as *const u8,
-                        ctx.contents.data_length,
-                    )
-                }
-            };
-            match T::decode_slice(bytes) {
-                Ok(data) => BufferMappingData::Owned(data),
-                Err(err) => {
-                    unsafe {
-                        sys::iree_hal_buffer_unmap_range(&mut ctx);
-                    }
-                    return Err(err);
-                }
-            }
-        };
-        Ok(Self {
-            ctx,
-            _buffer: buffer,
-            data,
-        })
     }
 
-    pub fn data(&self) -> &[T] {
-        match &self.data {
-            BufferMappingData::Mapped { element_len } => {
-                if *element_len == 0 {
-                    return &[];
-                }
-                unsafe {
-                    core::slice::from_raw_parts(self.ctx.contents.data as *const T, *element_len)
-                }
+    pub(crate) unsafe fn from_raw_retained(
+        ctx: *mut sys::iree_hal_buffer_view_t,
+        device: &Device,
+    ) -> Result<Self, RuntimeError> {
+        let element_type = unsafe { sys::iree_hal_buffer_view_element_type(ctx) };
+        match element_type {
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BOOL_8 => Ok(Value::Bool(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_8 => Ok(Value::U8(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_16 => Ok(Value::U16(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_32 => Ok(Value::U32(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_UINT_64 => Ok(Value::U64(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_8 => Ok(Value::I8(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_16 => Ok(Value::I16(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_32 => Ok(Value::I32(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_64 => Ok(Value::I64(unsafe {
+                BufferView::from_raw_retained(ctx, device)
+            })),
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16 => {
+                Ok(Value::F16(unsafe {
+                    BufferView::from_raw_retained(ctx, device)
+                }))
             }
-            BufferMappingData::Owned(data) => data,
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_32 => {
+                Ok(Value::F32(unsafe {
+                    BufferView::from_raw_retained(ctx, device)
+                }))
+            }
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_64 => {
+                Ok(Value::F64(unsafe {
+                    BufferView::from_raw_retained(ctx, device)
+                }))
+            }
+            sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16 => {
+                Ok(Value::Bf16(unsafe {
+                    BufferView::from_raw_retained(ctx, device)
+                }))
+            }
+            _ => Err(RuntimeError::InvalidArgument(format!(
+                "unsupported buffer element type {}",
+                element_type_name(element_type)
+            ))),
         }
     }
 }
 
-impl<T: BufferElement> Drop for BufferMapping<T> {
-    fn drop(&mut self) {
-        unsafe {
-            debug!("Releasing BufferMapping...");
-            sys::iree_hal_buffer_unmap_range(&mut self.ctx);
+macro_rules! impl_value_conversion {
+    ($variant:ident, $type:ty, $name:literal) => {
+        impl From<BufferView<$type>> for Value {
+            fn from(buffer: BufferView<$type>) -> Self {
+                Value::$variant(buffer)
+            }
         }
-    }
+
+        impl From<&BufferView<$type>> for Value {
+            fn from(buffer: &BufferView<$type>) -> Self {
+                Value::$variant(buffer.clone())
+            }
+        }
+
+        impl TryFrom<Value> for BufferView<$type> {
+            type Error = RuntimeError;
+
+            fn try_from(value: Value) -> Result<Self, Self::Error> {
+                match value {
+                    Value::$variant(buffer) => Ok(buffer),
+                    other => Err(RuntimeError::InvalidArgument(format!(
+                        "value type mismatch: expected {}, got {}",
+                        $name,
+                        other.type_name()
+                    ))),
+                }
+            }
+        }
+    };
 }
+
+impl_value_conversion!(Bool, bool, "bool");
+impl_value_conversion!(U8, u8, "u8");
+impl_value_conversion!(U16, u16, "u16");
+impl_value_conversion!(U32, u32, "u32");
+impl_value_conversion!(U64, u64, "u64");
+impl_value_conversion!(I8, i8, "i8");
+impl_value_conversion!(I16, i16, "i16");
+impl_value_conversion!(I32, i32, "i32");
+impl_value_conversion!(I64, i64, "i64");
+impl_value_conversion!(F16, f16, "f16");
+impl_value_conversion!(F32, f32, "f32");
+impl_value_conversion!(F64, f64, "f64");
+impl_value_conversion!(Bf16, bf16, "bf16");

--- a/src/runtime/high_level.rs
+++ b/src/runtime/high_level.rs
@@ -1,0 +1,171 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use super::{
+    base,
+    error::RuntimeError,
+    hal::{self, BufferElement, BufferView, Value},
+    vm::{self, ToRef},
+};
+
+/// Runtime HAL driver selection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Driver {
+    LocalSync,
+    #[cfg(feature = "std")]
+    LocalTask,
+    #[cfg(all(feature = "std", target_os = "macos"))]
+    Metal,
+    #[cfg(all(feature = "std", feature = "cuda"))]
+    Cuda,
+}
+
+impl Driver {
+    const fn name(self) -> &'static str {
+        match self {
+            Driver::LocalSync => "local-sync",
+            #[cfg(feature = "std")]
+            Driver::LocalTask => "local-task",
+            #[cfg(all(feature = "std", target_os = "macos"))]
+            Driver::Metal => "metal",
+            #[cfg(all(feature = "std", feature = "cuda"))]
+            Driver::Cuda => "cuda",
+        }
+    }
+}
+
+/// A configured IREE runtime with one HAL device.
+///
+/// `Runtime` owns the low-level driver objects needed to keep the selected
+/// device alive. Load VMFB modules into `Program`s and reuse them for calls.
+pub struct Runtime {
+    instance: vm::Instance,
+    _registry: hal::DriverRegistry,
+    _driver: hal::Driver,
+    device: hal::Device,
+    _not_send_sync: base::NotSendSync,
+}
+
+impl Runtime {
+    /// Creates a runtime using the selected HAL driver and its default device.
+    pub fn new(driver: Driver) -> Result<Self, RuntimeError> {
+        let instance = vm::Instance::global()?;
+        let registry = hal::DriverRegistry::with_available_drivers()?;
+        let driver = registry.create_driver(driver.name())?;
+        let device = driver.create_default_device()?;
+        Ok(Self {
+            instance,
+            _registry: registry,
+            _driver: driver,
+            device,
+            _not_send_sync: base::not_send_sync(),
+        })
+    }
+
+    /// Loads a VMFB archive into an executable program.
+    pub fn load_vmfb(&self, bytes: &[u8]) -> Result<Program, RuntimeError> {
+        Program::load(self, bytes)
+    }
+
+    /// Allocates a dense row-major typed buffer view on this runtime's device.
+    pub fn buffer_view<T: BufferElement>(
+        &self,
+        shape: &[usize],
+        data: &[T],
+    ) -> Result<BufferView<T>, RuntimeError> {
+        BufferView::from_host(&self.device, shape, data)
+    }
+}
+
+/// A loaded VMFB program with its own VM context.
+pub struct Program {
+    instance: vm::Instance,
+    device: hal::Device,
+    context: vm::Context,
+    _hal_module: vm::Module,
+    _bytecode_module: vm::Module,
+    _not_send_sync: base::NotSendSync,
+}
+
+impl Program {
+    fn load(runtime: &Runtime, bytes: &[u8]) -> Result<Self, RuntimeError> {
+        let hal_module = vm::Module::hal(&runtime.instance, &runtime.device)?;
+        let bytecode_module = vm::Module::bytecode(&runtime.instance, bytes)?;
+        let context =
+            vm::Context::with_modules(&runtime.instance, &[&hal_module, &bytecode_module])?;
+        Ok(Self {
+            instance: runtime.instance.clone(),
+            device: runtime.device.clone(),
+            context,
+            _hal_module: hal_module,
+            _bytecode_module: bytecode_module,
+            _not_send_sync: base::not_send_sync(),
+        })
+    }
+
+    pub fn function(&self, name: &str) -> Result<Function, RuntimeError> {
+        Ok(Function {
+            inner: self.context.resolve_function(name)?,
+            instance: self.instance.clone(),
+            device: self.device.clone(),
+            _not_send_sync: base::not_send_sync(),
+        })
+    }
+}
+
+fn push_value(
+    list: &mut vm::List<vm::Undefined>,
+    instance: &vm::Instance,
+    value: &Value,
+) -> Result<(), RuntimeError> {
+    match value {
+        Value::Bool(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::U8(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::U16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::U32(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::U64(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::I8(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::I16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::I32(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::I64(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::F16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::F32(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::F64(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        Value::Bf16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+    }
+    Ok(())
+}
+
+/// A resolved program function.
+pub struct Function {
+    inner: vm::Function,
+    instance: vm::Instance,
+    device: hal::Device,
+    _not_send_sync: base::NotSendSync,
+}
+
+impl Function {
+    /// Invokes with HAL buffer-view inputs and returns dynamically typed outputs.
+    pub fn invoke<I, V>(&self, inputs: I) -> Result<Vec<Value>, RuntimeError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<Value>,
+    {
+        let inputs = inputs.into_iter().map(Into::into).collect::<Vec<_>>();
+        let mut input_list = vm::List::<vm::Undefined>::new(inputs.len(), &self.instance)?;
+        for input in &inputs {
+            push_value(&mut input_list, &self.instance, input)?;
+        }
+
+        let output_count = self.inner.result_count()?;
+        let mut output_list = vm::List::<vm::Undefined>::new(output_count, &self.instance)?;
+        self.inner.invoke(&input_list, &mut output_list)?;
+
+        let mut outputs = Vec::with_capacity(output_count);
+        for index in 0..output_count {
+            outputs.push(output_list.get_buffer_view_value(index, &self.device)?);
+        }
+        Ok(outputs)
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,9 @@
-pub mod base;
-pub mod error;
-pub mod hal;
-pub mod vm;
+mod base;
+mod error;
+mod hal;
+mod high_level;
+mod vm;
+
+pub use error::{RuntimeError, StatusError};
+pub use hal::{BufferElement, BufferView, Value};
+pub use high_level::{Driver, Function, Program, Runtime};

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -11,8 +11,12 @@ use log::trace;
 use super::{
     base::{self, ConstByteSpan, StringView},
     error::RuntimeError,
-    hal::{BufferElement, BufferView, Device},
+    hal::{BufferElement, BufferView, Device, Value},
 };
+
+mod private {
+    pub trait Sealed {}
+}
 
 #[cfg(feature = "std")]
 // Owns the root VM instance ref for the program lifetime. HAL type adapters are
@@ -24,15 +28,8 @@ static GLOBAL_INSTANCE: Mutex<Option<usize>> = Mutex::new(None);
 // process-global in IREE, so the root is intentionally not torn down/recreated.
 static mut GLOBAL_INSTANCE: usize = 0;
 
-fn string_view_to_string(value: sys::iree_string_view_t) -> String {
-    if value.data.is_null() || value.size == 0 {
-        return String::new();
-    }
-    let bytes = unsafe { core::slice::from_raw_parts(value.data as *const u8, value.size) };
-    String::from_utf8_lossy(bytes).into_owned()
-}
-
 fn create_registered_instance() -> Result<*mut sys::iree_vm_instance_t, RuntimeError> {
+    let _guard = base::runtime_lifecycle_guard();
     let allocator = base::Allocator::get_global();
     let mut ctx = core::ptr::null_mut();
     base::Status::from_raw(unsafe {
@@ -42,10 +39,10 @@ fn create_registered_instance() -> Result<*mut sys::iree_vm_instance_t, RuntimeE
             &mut ctx,
         )
     })
-    .to_result()?;
+    .into_result()?;
 
     let status = base::Status::from_raw(unsafe { sys::iree_hal_module_register_all_types(ctx) });
-    if let Err(err) = status.to_result() {
+    if let Err(err) = status.into_result() {
         unsafe {
             sys::iree_vm_instance_release(ctx);
         }
@@ -55,15 +52,11 @@ fn create_registered_instance() -> Result<*mut sys::iree_vm_instance_t, RuntimeE
     Ok(ctx)
 }
 
-fn resolve_hal_types(instance: &Instance) -> Result<(), RuntimeError> {
-    base::Status::from_raw(unsafe { sys::iree_hal_module_resolve_all_types(instance.ctx) })
-        .to_result()
-        .map_err(Into::into)
-}
-
 #[cfg(feature = "std")]
 fn global_instance() -> Result<Instance, RuntimeError> {
-    let mut global = GLOBAL_INSTANCE.lock().unwrap();
+    let mut global = GLOBAL_INSTANCE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let ctx = match *global {
         Some(ctx) => ctx as *mut sys::iree_vm_instance_t,
         None => {
@@ -88,8 +81,9 @@ fn global_instance() -> Result<Instance, RuntimeError> {
 }
 
 /// A VM instance owns registered VM ref types and VM-level host allocation.
-pub struct Instance {
+pub(crate) struct Instance {
     pub(crate) ctx: *mut sys::iree_vm_instance_t,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl Instance {
@@ -104,7 +98,7 @@ impl Instance {
     /// The root VM instance is retained for the lifetime of the process or
     /// embedded program. Dropping an `Instance` releases the returned handle,
     /// but does not tear down the shared runtime root.
-    pub fn global() -> Result<Self, RuntimeError> {
+    pub(crate) fn global() -> Result<Self, RuntimeError> {
         global_instance()
     }
 
@@ -112,17 +106,16 @@ impl Instance {
         unsafe {
             sys::iree_vm_instance_retain(ctx);
         }
-        Self { ctx }
+        Self {
+            ctx,
+            _not_send_sync: base::not_send_sync(),
+        }
     }
 
     pub(crate) fn allocator(&self) -> base::Allocator {
         base::Allocator {
             ctx: unsafe { sys::iree_vm_instance_allocator(self.ctx) },
         }
-    }
-
-    pub(crate) fn lookup_type(&self, name: &str) -> sys::iree_vm_ref_type_t {
-        unsafe { sys::iree_vm_instance_lookup_type(self.ctx, StringView::from(name).ctx) }
     }
 }
 
@@ -141,15 +134,18 @@ impl Drop for Instance {
 }
 
 /// A VM module retained by Rust.
-pub struct Module {
+pub(crate) struct Module {
     pub(crate) ctx: *mut sys::iree_vm_module_t,
     instance: Instance,
     archive: Option<Rc<[u8]>>,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl Module {
     /// Creates the IREE HAL VM module bound to `device`.
-    pub fn hal(instance: &Instance, device: &Device) -> Result<Self, RuntimeError> {
+    pub(crate) fn hal(instance: &Instance, device: &Device) -> Result<Self, RuntimeError> {
+        let _guard = base::runtime_lifecycle_guard();
+
         let mut ctx = core::ptr::null_mut();
         let mut device_group = core::ptr::null_mut();
         base::Status::from_raw(unsafe {
@@ -159,7 +155,7 @@ impl Module {
                 &mut device_group,
             )
         })
-        .to_result()?;
+        .into_result()?;
         let status = base::Status::from_raw(unsafe {
             sys::iree_hal_module_create(
                 instance.ctx,
@@ -174,11 +170,12 @@ impl Module {
         unsafe {
             sys::iree_hal_device_group_release(device_group);
         }
-        status.to_result()?;
+        status.into_result()?;
         Ok(Self {
             ctx,
             instance: instance.clone(),
             archive: None,
+            _not_send_sync: base::not_send_sync(),
         })
     }
 
@@ -187,7 +184,9 @@ impl Module {
     /// IREE does not retain or copy the archive bytes, so this method copies the
     /// input into ref-counted Rust-owned storage and keeps it alive with the
     /// retained module handle.
-    pub fn bytecode(instance: &Instance, data: &[u8]) -> Result<Self, RuntimeError> {
+    pub(crate) fn bytecode(instance: &Instance, data: &[u8]) -> Result<Self, RuntimeError> {
+        let _guard = base::runtime_lifecycle_guard();
+
         let archive = Rc::<[u8]>::from(data);
         let bytes: ConstByteSpan = archive.as_ref().into();
         let mut ctx = core::ptr::null_mut();
@@ -201,161 +200,23 @@ impl Module {
                 &mut ctx,
             )
         })
-        .to_result()?;
+        .into_result()?;
         Ok(Self {
             ctx,
             instance: instance.clone(),
             archive: Some(archive),
+            _not_send_sync: base::not_send_sync(),
         })
     }
 
-    pub fn name(&self) -> String {
-        string_view_to_string(unsafe { sys::iree_vm_module_name(self.ctx) })
-    }
-
-    pub fn signature(&self) -> ModuleSignature {
-        let ctx = unsafe { sys::iree_vm_module_signature(self.ctx) };
-        ModuleSignature {
-            version: ctx.version,
-            attr_count: ctx.attr_count,
-            import_function_count: ctx.import_function_count,
-            export_function_count: ctx.export_function_count,
-            internal_function_count: ctx.internal_function_count,
+    fn release_unlocked(&mut self) {
+        if self.ctx.is_null() {
+            return;
         }
-    }
-
-    pub fn lookup_attr(&self, key: &str) -> Option<String> {
-        let value = string_view_to_string(unsafe {
-            sys::iree_vm_module_lookup_attr_by_name(self.ctx, StringView::from(key).ctx)
-        });
-        (!value.is_empty()).then_some(value)
-    }
-
-    pub fn attr(&self, index: usize) -> Result<Option<StringPair>, RuntimeError> {
-        let mut pair = sys::iree_string_pair_t::default();
-        let status = base::Status::from_raw(unsafe {
-            sys::iree_vm_module_get_attr(self.ctx, index, &mut pair)
-        });
-        match status.to_result() {
-            Ok(()) => Ok(Some(string_pair_to_owned(pair))),
-            Err(err) => {
-                let _ = err;
-                Ok(None)
-            }
+        unsafe {
+            sys::iree_vm_module_release(self.ctx);
         }
-    }
-
-    pub fn lookup_export_function(&self, name: &str) -> Result<FunctionRef, RuntimeError> {
-        self.lookup_function(name, FunctionLinkage::Export)
-    }
-
-    pub fn lookup_function(
-        &self,
-        name: &str,
-        linkage: FunctionLinkage,
-    ) -> Result<FunctionRef, RuntimeError> {
-        let mut ctx = sys::iree_vm_function_t::default();
-        base::Status::from_raw(unsafe {
-            sys::iree_vm_module_lookup_function_by_name(
-                self.ctx,
-                linkage.into(),
-                StringView::from(name).ctx,
-                &mut ctx,
-            )
-        })
-        .to_result()?;
-        Ok(FunctionRef { ctx })
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ModuleSignature {
-    pub version: u32,
-    pub attr_count: usize,
-    pub import_function_count: usize,
-    pub export_function_count: usize,
-    pub internal_function_count: usize,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct StringPair {
-    pub key: String,
-    pub value: String,
-}
-
-fn string_pair_to_owned(pair: sys::iree_string_pair_t) -> StringPair {
-    unsafe {
-        StringPair {
-            key: string_view_to_string(pair.__bindgen_anon_1.key),
-            value: string_view_to_string(pair.__bindgen_anon_2.value),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FunctionLinkage {
-    Internal,
-    Import,
-    Export,
-    ImportOptional,
-    ExportOptional,
-}
-
-impl From<FunctionLinkage> for sys::iree_vm_function_linkage_t {
-    fn from(value: FunctionLinkage) -> Self {
-        match value {
-            FunctionLinkage::Internal => {
-                sys::iree_vm_function_linkage_e_IREE_VM_FUNCTION_LINKAGE_INTERNAL
-            }
-            FunctionLinkage::Import => {
-                sys::iree_vm_function_linkage_e_IREE_VM_FUNCTION_LINKAGE_IMPORT
-            }
-            FunctionLinkage::Export => {
-                sys::iree_vm_function_linkage_e_IREE_VM_FUNCTION_LINKAGE_EXPORT
-            }
-            FunctionLinkage::ImportOptional => {
-                sys::iree_vm_function_linkage_e_IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL
-            }
-            FunctionLinkage::ExportOptional => {
-                sys::iree_vm_function_linkage_e_IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL
-            }
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub struct FunctionRef {
-    ctx: sys::iree_vm_function_t,
-}
-
-impl FunctionRef {
-    pub fn name(&self) -> String {
-        string_view_to_string(unsafe { sys::iree_vm_function_name(&self.ctx) })
-    }
-
-    pub fn signature(&self) -> FunctionSignature {
-        Function::signature_from_raw(&self.ctx)
-    }
-
-    pub fn lookup_attr(&self, key: &str) -> Option<String> {
-        let value = string_view_to_string(unsafe {
-            sys::iree_vm_function_lookup_attr_by_name(&self.ctx, StringView::from(key).ctx)
-        });
-        (!value.is_empty()).then_some(value)
-    }
-
-    pub fn attr(&self, index: usize) -> Result<Option<StringPair>, RuntimeError> {
-        let mut pair = sys::iree_string_pair_t::default();
-        let status = base::Status::from_raw(unsafe {
-            sys::iree_vm_function_get_attr(self.ctx, index, &mut pair)
-        });
-        match status.to_result() {
-            Ok(()) => Ok(Some(string_pair_to_owned(pair))),
-            Err(err) => {
-                let _ = err;
-                Ok(None)
-            }
-        }
+        self.ctx = core::ptr::null_mut();
     }
 }
 
@@ -368,27 +229,38 @@ impl Clone for Module {
             ctx: self.ctx,
             instance: self.instance.clone(),
             archive: self.archive.clone(),
+            _not_send_sync: base::not_send_sync(),
         }
     }
 }
 
 impl Drop for Module {
     fn drop(&mut self) {
-        unsafe {
-            sys::iree_vm_module_release(self.ctx);
+        if self.ctx.is_null() {
+            return;
         }
+
+        let _guard = base::runtime_lifecycle_guard();
+
+        self.release_unlocked();
     }
 }
 
 /// A VM context with a fixed module set.
-pub struct Context {
+pub(crate) struct Context {
     pub(crate) ctx: *mut sys::iree_vm_context_t,
     instance: Instance,
     modules: Vec<Module>,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl Context {
-    pub fn with_modules(instance: &Instance, modules: &[&Module]) -> Result<Self, RuntimeError> {
+    pub(crate) fn with_modules(
+        instance: &Instance,
+        modules: &[&Module],
+    ) -> Result<Self, RuntimeError> {
+        let _guard = base::runtime_lifecycle_guard();
+
         let mut ctx = core::ptr::null_mut();
         let mut raw_modules: Vec<*mut sys::iree_vm_module_t> =
             modules.iter().map(|module| module.ctx).collect();
@@ -402,28 +274,26 @@ impl Context {
                 &mut ctx,
             )
         })
-        .to_result()?;
+        .into_result()?;
         Ok(Self {
             ctx,
             instance: instance.clone(),
             modules: modules.iter().map(|module| (*module).clone()).collect(),
+            _not_send_sync: base::not_send_sync(),
         })
     }
 
-    pub fn resolve_function(&self, name: &str) -> Result<Function, RuntimeError> {
+    pub(crate) fn resolve_function(&self, name: &str) -> Result<Function, RuntimeError> {
         let mut ctx = sys::iree_vm_function_t::default();
         base::Status::from_raw(unsafe {
             sys::iree_vm_context_resolve_function(self.ctx, StringView::from(name).ctx, &mut ctx)
         })
-        .to_result()?;
+        .into_result()?;
         Ok(Function {
             ctx,
             context: self.clone(),
+            _not_send_sync: base::not_send_sync(),
         })
-    }
-
-    pub fn instance(&self) -> &Instance {
-        &self.instance
     }
 }
 
@@ -436,88 +306,59 @@ impl Clone for Context {
             ctx: self.ctx,
             instance: self.instance.clone(),
             modules: self.modules.clone(),
+            _not_send_sync: base::not_send_sync(),
         }
     }
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
+        let _guard = base::runtime_lifecycle_guard();
+
         unsafe {
             sys::iree_vm_context_release(self.ctx);
+        }
+        self.ctx = core::ptr::null_mut();
+
+        for mut module in self.modules.drain(..) {
+            module.release_unlocked();
         }
     }
 }
 
 /// An exported VM function resolved against a context.
-pub struct Function {
+pub(crate) struct Function {
     pub(crate) ctx: sys::iree_vm_function_t,
     context: Context,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl Function {
-    pub fn name(&self) -> String {
-        string_view_to_string(unsafe { sys::iree_vm_function_name(&self.ctx) })
-    }
-
-    pub fn signature(&self) -> FunctionSignature {
-        Self::signature_from_raw(&self.ctx)
-    }
-
-    fn signature_from_raw(function: &sys::iree_vm_function_t) -> FunctionSignature {
-        let ctx = unsafe { sys::iree_vm_function_signature(function) };
-        let calling_convention = string_view_to_string(ctx.calling_convention);
-        let (argument_count, result_count) =
-            Self::count_arguments_and_results(&ctx).unwrap_or((0, 0));
-        FunctionSignature {
-            calling_convention,
-            argument_count,
-            result_count,
-        }
-    }
-
-    pub fn lookup_attr(&self, key: &str) -> Option<String> {
-        let value = string_view_to_string(unsafe {
-            sys::iree_vm_function_lookup_attr_by_name(&self.ctx, StringView::from(key).ctx)
-        });
-        (!value.is_empty()).then_some(value)
-    }
-
-    pub fn attr(&self, index: usize) -> Result<Option<StringPair>, RuntimeError> {
-        let mut pair = sys::iree_string_pair_t::default();
-        let status = base::Status::from_raw(unsafe {
-            sys::iree_vm_function_get_attr(self.ctx, index, &mut pair)
-        });
-        match status.to_result() {
-            Ok(()) => Ok(Some(string_pair_to_owned(pair))),
-            Err(err) => {
-                let _ = err;
-                Ok(None)
-            }
-        }
-    }
-
-    fn count_arguments_and_results(
-        signature: &sys::iree_vm_function_signature_t,
-    ) -> Result<(usize, usize), RuntimeError> {
+    pub(crate) fn result_count(&self) -> Result<usize, RuntimeError> {
+        let signature = unsafe { sys::iree_vm_function_signature(&self.ctx) };
         let mut argument_count = 0usize;
         let mut result_count = 0usize;
         base::Status::from_raw(unsafe {
             sys::iree_vm_function_call_count_arguments_and_results(
-                signature,
+                &signature,
                 &mut argument_count,
                 &mut result_count,
             )
         })
-        .to_result()?;
-        Ok((argument_count, result_count))
+        .into_result()?;
+        Ok(result_count)
     }
 
-    pub fn invoke<I, O>(&self, inputs: &List<I>, outputs: &mut List<O>) -> Result<(), RuntimeError>
+    pub(crate) fn invoke<I, O>(
+        &self,
+        inputs: &List<I>,
+        outputs: &mut List<O>,
+    ) -> Result<(), RuntimeError>
     where
         I: Type,
         O: Type,
     {
-        resolve_hal_types(&self.context.instance)?;
+        let _guard = base::runtime_invocation_guard();
         base::Status::from_raw(unsafe {
             trace!("iree_vm_invoke");
             sys::iree_vm_invoke(
@@ -530,17 +371,9 @@ impl Function {
                 self.context.instance.allocator().ctx,
             )
         })
-        .to_result()
+        .into_result()
         .map_err(Into::into)
     }
-}
-
-/// Reflected VM function signature metadata.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FunctionSignature {
-    pub calling_convention: String,
-    pub argument_count: usize,
-    pub result_count: usize,
 }
 
 impl Clone for Function {
@@ -548,97 +381,36 @@ impl Clone for Function {
         Self {
             ctx: self.ctx,
             context: self.context.clone(),
+            _not_send_sync: base::not_send_sync(),
         }
     }
 }
 
 /// Trait for VM list element types.
-pub trait Type {
+pub(crate) trait Type: private::Sealed {
     fn type_def(instance: &Instance) -> sys::iree_vm_type_def_t;
 }
 
-/// Trait for values that can be stored in VM lists.
-pub trait ToValue: Sized {
-    fn to_value(&self) -> Value<Self>;
-    fn value_type() -> sys::iree_vm_value_type_e;
-}
-
-macro_rules! impl_to_value {
-    ($type:ty, $variant:ident, $enum:ident) => {
-        impl ToValue for $type {
-            fn to_value(&self) -> Value<Self> {
-                let mut out = sys::iree_vm_value_t::default();
-                out.type_ = Self::value_type();
-                out.__bindgen_anon_1.$variant = *self;
-                Value {
-                    ctx: out,
-                    _marker: PhantomData,
-                }
-            }
-
-            fn value_type() -> sys::iree_vm_value_type_e {
-                sys::$enum
-            }
-        }
-    };
-}
-
-impl_to_value!(i8, i8_, iree_vm_value_type_e_IREE_VM_VALUE_TYPE_I8);
-impl_to_value!(i16, i16_, iree_vm_value_type_e_IREE_VM_VALUE_TYPE_I16);
-impl_to_value!(i32, i32_, iree_vm_value_type_e_IREE_VM_VALUE_TYPE_I32);
-impl_to_value!(i64, i64_, iree_vm_value_type_e_IREE_VM_VALUE_TYPE_I64);
-impl_to_value!(f32, f32_, iree_vm_value_type_e_IREE_VM_VALUE_TYPE_F32);
-impl_to_value!(f64, f64_, iree_vm_value_type_e_IREE_VM_VALUE_TYPE_F64);
-
-/// A VM scalar value.
-pub struct Value<T: ToValue> {
-    pub(crate) ctx: sys::iree_vm_value_t,
-    _marker: PhantomData<T>,
-}
-
-impl<T: ToValue> Type for Value<T> {
-    fn type_def(_: &Instance) -> sys::iree_vm_type_def_t {
-        let mut out = sys::iree_vm_type_def_t::default();
-        out.set_value_type_bits(T::value_type() as usize);
-        out.set_ref_type_bits(sys::iree_vm_ref_type_bits_t_IREE_VM_REF_TYPE_NULL as usize);
-        out
-    }
-}
-
-macro_rules! impl_value {
-    ($type:ty, $variant:ident) => {
-        impl Value<$type> {
-            pub fn get(&self) -> $type {
-                unsafe { self.ctx.__bindgen_anon_1.$variant }
-            }
-        }
-    };
-}
-
-impl_value!(i8, i8_);
-impl_value!(i16, i16_);
-impl_value!(i32, i32_);
-impl_value!(i64, i64_);
-impl_value!(f32, f32_);
-impl_value!(f64, f64_);
-
-pub trait RefObject {
+pub(crate) trait RefObject: private::Sealed {
     fn ref_type(instance: &Instance) -> sys::iree_vm_ref_type_t;
 }
 
 /// Trait for objects that can be converted to VM refs.
-pub trait ToRef: RefObject {
+pub(crate) trait ToRef: RefObject {
     fn to_ref(&self, instance: &Instance) -> Result<Ref<Self>, RuntimeError>
     where
         Self: Sized;
 }
 
 /// A VM reference.
-pub struct Ref<T: RefObject> {
+pub(crate) struct Ref<T: RefObject> {
     pub(crate) ctx: sys::iree_vm_ref_t,
     instance: Instance,
     _marker: PhantomData<T>,
+    _not_send_sync: base::NotSendSync,
 }
+
+impl<T: RefObject> private::Sealed for Ref<T> {}
 
 impl<T: RefObject> Type for Ref<T> {
     fn type_def(instance: &Instance) -> sys::iree_vm_type_def_t {
@@ -662,6 +434,7 @@ impl<T: RefObject> Clone for Ref<T> {
             ctx,
             instance: self.instance.clone(),
             _marker: PhantomData,
+            _not_send_sync: base::not_send_sync(),
         }
     }
 }
@@ -676,53 +449,29 @@ impl<T: RefObject> Drop for Ref<T> {
 }
 
 impl<T: BufferElement> RefObject for BufferView<T> {
-    fn ref_type(instance: &Instance) -> sys::iree_vm_ref_type_t {
-        instance.lookup_type("hal.buffer_view")
+    fn ref_type(_instance: &Instance) -> sys::iree_vm_ref_type_t {
+        unsafe { sys::iree_hal_buffer_view_registration }
     }
 }
 
+impl<T: BufferElement> private::Sealed for BufferView<T> {}
+
 impl<T: BufferElement> ToRef for BufferView<T> {
     fn to_ref(&self, instance: &Instance) -> Result<Ref<Self>, RuntimeError> {
-        let mut ctx = sys::iree_vm_ref_t::default();
-        base::Status::from_raw(unsafe {
-            sys::iree_vm_ref_wrap_retain(
-                self.ctx as *mut core::ffi::c_void,
-                Self::ref_type(instance),
-                &mut ctx,
-            )
-        })
-        .to_result()?;
+        let ctx = unsafe { sys::iree_hal_buffer_view_retain_ref(self.ctx) };
         Ok(Ref {
             ctx,
             instance: instance.clone(),
             _marker: PhantomData,
+            _not_send_sync: base::not_send_sync(),
         })
     }
 }
 
-impl<T: BufferElement> Ref<BufferView<T>> {
-    pub fn to_buffer_view(&self) -> Result<BufferView<T>, RuntimeError> {
-        if self.ctx.type_ != BufferView::<T>::ref_type(&self.instance) {
-            return Err(RuntimeError::InvalidArgument(String::from(
-                "VM ref type mismatch: expected hal.buffer_view",
-            )));
-        }
-        let buffer = unsafe {
-            BufferView::from_raw_retained(self.ctx.ptr as *mut sys::iree_hal_buffer_view_t)
-        };
-        if buffer.element_type() != T::element_type() {
-            return Err(RuntimeError::InvalidArgument(alloc::format!(
-                "buffer element type mismatch: expected {:?}, got {:?}",
-                T::element_type(),
-                buffer.element_type()
-            )));
-        }
-        Ok(buffer)
-    }
-}
-
 /// Undefined list element type. Use for heterogenous VM argument/result lists.
-pub struct Undefined;
+pub(crate) struct Undefined;
+
+impl private::Sealed for Undefined {}
 
 impl Type for Undefined {
     fn type_def(_: &Instance) -> sys::iree_vm_type_def_t {
@@ -733,30 +482,16 @@ impl Type for Undefined {
     }
 }
 
-/// Any VM ref list element type.
-pub struct AnyRef;
-
-impl Type for AnyRef {
-    fn type_def(_: &Instance) -> sys::iree_vm_type_def_t {
-        let mut out = sys::iree_vm_type_def_t::default();
-        out.set_value_type_bits(sys::iree_vm_value_type_e_IREE_VM_VALUE_TYPE_NONE as usize);
-        out.set_ref_type_bits(
-            sys::iree_vm_ref_type_bits_t_IREE_VM_REF_TYPE_ANY as usize
-                / (1usize << sys::IREE_VM_REF_TYPE_TAG_BITS as usize),
-        );
-        out
-    }
-}
-
 /// An owned dynamic VM list.
-pub struct List<T: Type> {
+pub(crate) struct List<T: Type> {
     pub(crate) ctx: *mut sys::iree_vm_list_t,
     instance: Instance,
     _marker: PhantomData<T>,
+    _not_send_sync: base::NotSendSync,
 }
 
 impl<T: Type> List<T> {
-    pub fn new(initial_capacity: usize, instance: &Instance) -> Result<Self, RuntimeError> {
+    pub(crate) fn new(initial_capacity: usize, instance: &Instance) -> Result<Self, RuntimeError> {
         let mut ctx = core::ptr::null_mut();
         base::Status::from_raw(unsafe {
             sys::iree_vm_list_create(
@@ -766,92 +501,56 @@ impl<T: Type> List<T> {
                 &mut ctx,
             )
         })
-        .to_result()?;
+        .into_result()?;
         Ok(Self {
             ctx,
             instance: instance.clone(),
             _marker: PhantomData,
+            _not_send_sync: base::not_send_sync(),
         })
     }
 
-    pub fn capacity(&self) -> usize {
-        unsafe { sys::iree_vm_list_capacity(self.ctx) }
-    }
-
-    pub fn reserve(&mut self, minimum_capacity: usize) -> Result<(), RuntimeError> {
-        base::Status::from_raw(unsafe { sys::iree_vm_list_reserve(self.ctx, minimum_capacity) })
-            .to_result()
-            .map_err(Into::into)
-    }
-
-    pub fn resize(&mut self, new_size: usize) -> Result<(), RuntimeError> {
-        base::Status::from_raw(unsafe { sys::iree_vm_list_resize(self.ctx, new_size) })
-            .to_result()
-            .map_err(Into::into)
-    }
-
-    pub fn clear(&mut self) {
-        unsafe {
-            sys::iree_vm_list_clear(self.ctx);
-        }
-    }
-
-    pub fn push_value<A: ToValue>(&mut self, value: Value<A>) -> Result<(), RuntimeError> {
-        base::Status::from_raw(unsafe { sys::iree_vm_list_push_value(self.ctx, &value.ctx) })
-            .to_result()
-            .map_err(Into::into)
-    }
-
-    pub fn set_value<A: ToValue>(
-        &mut self,
-        idx: usize,
-        value: Value<A>,
-    ) -> Result<(), RuntimeError> {
-        base::Status::from_raw(unsafe { sys::iree_vm_list_set_value(self.ctx, idx, &value.ctx) })
-            .to_result()
-            .map_err(Into::into)
-    }
-
-    pub fn get_value<A: ToValue>(&self, idx: usize) -> Result<Value<A>, RuntimeError> {
-        let mut ctx = sys::iree_vm_value_t::default();
-        base::Status::from_raw(unsafe { sys::iree_vm_list_get_value(self.ctx, idx, &mut ctx) })
-            .to_result()?;
-        if ctx.type_ != A::value_type() {
-            return Err(RuntimeError::InvalidArgument(String::from(
-                "VM value type mismatch",
-            )));
-        }
-        Ok(Value {
-            ctx,
-            _marker: PhantomData,
-        })
-    }
-
-    pub fn push_ref<A: RefObject>(&mut self, value: &Ref<A>) -> Result<(), RuntimeError> {
+    pub(crate) fn push_ref<A: RefObject>(&mut self, value: &Ref<A>) -> Result<(), RuntimeError> {
         base::Status::from_raw(unsafe { sys::iree_vm_list_push_ref_retain(self.ctx, &value.ctx) })
-            .to_result()
+            .into_result()
             .map_err(Into::into)
     }
 
-    pub fn get_ref<A: RefObject>(&self, idx: usize) -> Result<Ref<A>, RuntimeError> {
+    fn get_ref(&self, idx: usize) -> Result<sys::iree_vm_ref_t, RuntimeError> {
         let mut ctx = sys::iree_vm_ref_t::default();
         base::Status::from_raw(unsafe {
             sys::iree_vm_list_get_ref_retain(self.ctx, idx, &mut ctx)
         })
-        .to_result()?;
-        if ctx.type_ != A::ref_type(&self.instance) {
-            unsafe {
-                sys::iree_vm_ref_release(&mut ctx);
+        .into_result()?;
+        Ok(ctx)
+    }
+}
+
+impl List<Undefined> {
+    pub(crate) fn get_buffer_view_value(
+        &self,
+        idx: usize,
+        device: &Device,
+    ) -> Result<Value, RuntimeError> {
+        let mut ctx = self.get_ref(idx)?;
+        let result = (|| {
+            if ctx.type_ != unsafe { sys::iree_hal_buffer_view_registration } {
+                return Err(RuntimeError::InvalidArgument(String::from(
+                    "VM ref type mismatch",
+                )));
             }
-            return Err(RuntimeError::InvalidArgument(String::from(
-                "VM ref type mismatch",
-            )));
+
+            let mut ptr = core::ptr::null_mut();
+            base::Status::from_raw(unsafe { sys::iree_hal_buffer_view_check_deref(ctx, &mut ptr) })
+                .into_result()?;
+            unsafe { Value::from_raw_retained(ptr, device) }
+        })();
+
+        unsafe {
+            sys::iree_vm_ref_release(&mut ctx);
         }
-        Ok(Ref {
-            ctx,
-            instance: self.instance.clone(),
-            _marker: PhantomData,
-        })
+
+        result
     }
 }
 
@@ -864,6 +563,7 @@ impl<T: Type> Clone for List<T> {
             ctx: self.ctx,
             instance: self.instance.clone(),
             _marker: PhantomData,
+            _not_send_sync: base::not_send_sync(),
         }
     }
 }

--- a/src/runtime/vm.rs
+++ b/src/runtime/vm.rs
@@ -15,7 +15,14 @@ use super::{
 };
 
 #[cfg(feature = "std")]
-static HAL_TYPE_ADAPTER_LOCK: Mutex<()> = Mutex::new(());
+// Owns the root VM instance ref for the program lifetime. HAL type adapters are
+// process-global in IREE, so the root is intentionally not torn down/recreated.
+static GLOBAL_INSTANCE: Mutex<Option<usize>> = Mutex::new(None);
+
+#[cfg(not(feature = "std"))]
+// Owns the root VM instance ref for the program lifetime. HAL type adapters are
+// process-global in IREE, so the root is intentionally not torn down/recreated.
+static mut GLOBAL_INSTANCE: usize = 0;
 
 fn string_view_to_string(value: sys::iree_string_view_t) -> String {
     if value.data.is_null() || value.size == 0 {
@@ -25,6 +32,29 @@ fn string_view_to_string(value: sys::iree_string_view_t) -> String {
     String::from_utf8_lossy(bytes).into_owned()
 }
 
+fn create_registered_instance() -> Result<*mut sys::iree_vm_instance_t, RuntimeError> {
+    let allocator = base::Allocator::get_global();
+    let mut ctx = core::ptr::null_mut();
+    base::Status::from_raw(unsafe {
+        sys::iree_vm_instance_create(
+            sys::IREE_VM_TYPE_CAPACITY_DEFAULT as usize,
+            allocator.ctx,
+            &mut ctx,
+        )
+    })
+    .to_result()?;
+
+    let status = base::Status::from_raw(unsafe { sys::iree_hal_module_register_all_types(ctx) });
+    if let Err(err) = status.to_result() {
+        unsafe {
+            sys::iree_vm_instance_release(ctx);
+        }
+        return Err(err.into());
+    }
+
+    Ok(ctx)
+}
+
 fn resolve_hal_types(instance: &Instance) -> Result<(), RuntimeError> {
     base::Status::from_raw(unsafe { sys::iree_hal_module_resolve_all_types(instance.ctx) })
         .to_result()
@@ -32,61 +62,29 @@ fn resolve_hal_types(instance: &Instance) -> Result<(), RuntimeError> {
 }
 
 #[cfg(feature = "std")]
-fn with_hal_type_adapter_lock<T>(
-    f: impl FnOnce() -> Result<T, RuntimeError>,
-) -> Result<T, RuntimeError> {
-    let _guard = HAL_TYPE_ADAPTER_LOCK.lock().unwrap();
-    f()
+fn global_instance() -> Result<Instance, RuntimeError> {
+    let mut global = GLOBAL_INSTANCE.lock().unwrap();
+    let ctx = match *global {
+        Some(ctx) => ctx as *mut sys::iree_vm_instance_t,
+        None => {
+            let ctx = create_registered_instance()?;
+            *global = Some(ctx as usize);
+            ctx
+        }
+    };
+    Ok(Instance::retain_raw(ctx))
 }
 
 #[cfg(not(feature = "std"))]
-fn with_hal_type_adapter_lock<T>(
-    f: impl FnOnce() -> Result<T, RuntimeError>,
-) -> Result<T, RuntimeError> {
-    critical_section::with(|_| f())
-}
-
-fn with_hal_type_adapters<T>(
-    instance: &Instance,
-    f: impl FnOnce() -> Result<T, RuntimeError>,
-) -> Result<T, RuntimeError> {
-    with_hal_type_adapter_lock(|| {
-        resolve_hal_types(instance)?;
-        f()
+fn global_instance() -> Result<Instance, RuntimeError> {
+    critical_section::with(|_| unsafe {
+        if GLOBAL_INSTANCE == 0 {
+            GLOBAL_INSTANCE = create_registered_instance()? as usize;
+        }
+        Ok(Instance::retain_raw(
+            GLOBAL_INSTANCE as *mut sys::iree_vm_instance_t,
+        ))
     })
-}
-
-fn rebind_hal_refs<T: Type>(instance: &Instance, list: &List<T>) -> Result<(), RuntimeError> {
-    let count = unsafe { sys::iree_vm_list_size(list.ctx) };
-    for index in 0..count {
-        let mut value = sys::iree_vm_ref_t::default();
-        let status = base::Status::from_raw(unsafe {
-            sys::iree_vm_list_get_ref_assign(list.ctx, index, &mut value)
-        });
-        if status.to_result().is_err()
-            || value.type_
-                == sys::iree_vm_ref_type_bits_t_IREE_VM_REF_TYPE_NULL as sys::iree_vm_ref_type_t
-        {
-            continue;
-        }
-
-        let type_name = string_view_to_string(unsafe { sys::iree_vm_ref_type_name(value.type_) });
-        if !type_name.starts_with("hal.") {
-            continue;
-        }
-
-        let rebound_type = instance.lookup_type(&type_name);
-        if rebound_type == 0 || rebound_type == value.type_ {
-            continue;
-        }
-
-        value.type_ = rebound_type;
-        base::Status::from_raw(unsafe {
-            sys::iree_vm_list_set_ref_retain(list.ctx, index, &value)
-        })
-        .to_result()?;
-    }
-    Ok(())
 }
 
 /// A VM instance owns registered VM ref types and VM-level host allocation.
@@ -95,24 +93,26 @@ pub struct Instance {
 }
 
 impl Instance {
-    pub fn new() -> Result<Self, RuntimeError> {
-        let allocator = base::Allocator::get_global();
-        let mut ctx = core::ptr::null_mut();
-        base::Status::from_raw(unsafe {
-            sys::iree_vm_instance_create(
-                sys::IREE_VM_TYPE_CAPACITY_DEFAULT as usize,
-                allocator.ctx,
-                &mut ctx,
-            )
-        })
-        .to_result()?;
-        let instance = Self { ctx };
-        with_hal_type_adapter_lock(|| {
-            base::Status::from_raw(unsafe { sys::iree_hal_module_register_all_types(ctx) })
-                .to_result()?;
-            resolve_hal_types(&instance)
-        })?;
-        Ok(instance)
+    /// Returns a retained handle to the process-wide VM instance.
+    ///
+    /// This does not create an independent IREE VM instance.
+    /// IREE expects hosting applications to share VM instances across contexts.
+    /// HAL type registration uses process-global adapter slots, so the safe
+    /// runtime API exposes one shared instance instead of creating independent
+    /// HAL-registered instances.
+    ///
+    /// The root VM instance is retained for the lifetime of the process or
+    /// embedded program. Dropping an `Instance` releases the returned handle,
+    /// but does not tear down the shared runtime root.
+    pub fn global() -> Result<Self, RuntimeError> {
+        global_instance()
+    }
+
+    fn retain_raw(ctx: *mut sys::iree_vm_instance_t) -> Self {
+        unsafe {
+            sys::iree_vm_instance_retain(ctx);
+        }
+        Self { ctx }
     }
 
     pub(crate) fn allocator(&self) -> base::Allocator {
@@ -128,10 +128,7 @@ impl Instance {
 
 impl Clone for Instance {
     fn clone(&self) -> Self {
-        unsafe {
-            sys::iree_vm_instance_retain(self.ctx);
-        }
-        Self { ctx: self.ctx }
+        Self::retain_raw(self.ctx)
     }
 }
 
@@ -153,37 +150,35 @@ pub struct Module {
 impl Module {
     /// Creates the IREE HAL VM module bound to `device`.
     pub fn hal(instance: &Instance, device: &Device) -> Result<Self, RuntimeError> {
-        with_hal_type_adapters(instance, || {
-            let mut ctx = core::ptr::null_mut();
-            let mut device_group = core::ptr::null_mut();
-            base::Status::from_raw(unsafe {
-                sys::iree_hal_device_group_create_from_device(
-                    device.ctx,
-                    instance.allocator().ctx,
-                    &mut device_group,
-                )
-            })
-            .to_result()?;
-            let status = base::Status::from_raw(unsafe {
-                sys::iree_hal_module_create(
-                    instance.ctx,
-                    sys::iree_hal_module_device_policy_default(),
-                    device_group,
-                    sys::iree_hal_module_flag_bits_t_IREE_HAL_MODULE_FLAG_SYNCHRONOUS,
-                    sys::iree_hal_module_debug_sink_null(),
-                    instance.allocator().ctx,
-                    &mut ctx,
-                )
-            });
-            unsafe {
-                sys::iree_hal_device_group_release(device_group);
-            }
-            status.to_result()?;
-            Ok(Self {
-                ctx,
-                instance: instance.clone(),
-                archive: None,
-            })
+        let mut ctx = core::ptr::null_mut();
+        let mut device_group = core::ptr::null_mut();
+        base::Status::from_raw(unsafe {
+            sys::iree_hal_device_group_create_from_device(
+                device.ctx,
+                instance.allocator().ctx,
+                &mut device_group,
+            )
+        })
+        .to_result()?;
+        let status = base::Status::from_raw(unsafe {
+            sys::iree_hal_module_create(
+                instance.ctx,
+                sys::iree_hal_module_device_policy_default(),
+                device_group,
+                sys::iree_hal_module_flag_bits_t_IREE_HAL_MODULE_FLAG_SYNCHRONOUS,
+                sys::iree_hal_module_debug_sink_null(),
+                instance.allocator().ctx,
+                &mut ctx,
+            )
+        });
+        unsafe {
+            sys::iree_hal_device_group_release(device_group);
+        }
+        status.to_result()?;
+        Ok(Self {
+            ctx,
+            instance: instance.clone(),
+            archive: None,
         })
     }
 
@@ -522,23 +517,21 @@ impl Function {
         I: Type,
         O: Type,
     {
-        with_hal_type_adapters(&self.context.instance, || {
-            rebind_hal_refs(&self.context.instance, inputs)?;
-            base::Status::from_raw(unsafe {
-                trace!("iree_vm_invoke");
-                sys::iree_vm_invoke(
-                    self.context.ctx,
-                    self.ctx,
-                    sys::iree_vm_invocation_flag_bits_t_IREE_VM_INVOCATION_FLAG_NONE,
-                    core::ptr::null(),
-                    inputs.ctx,
-                    outputs.ctx,
-                    self.context.instance.allocator().ctx,
-                )
-            })
-            .to_result()
-            .map_err(Into::into)
+        resolve_hal_types(&self.context.instance)?;
+        base::Status::from_raw(unsafe {
+            trace!("iree_vm_invoke");
+            sys::iree_vm_invoke(
+                self.context.ctx,
+                self.ctx,
+                sys::iree_vm_invocation_flag_bits_t_IREE_VM_INVOCATION_FLAG_NONE,
+                core::ptr::null(),
+                inputs.ctx,
+                outputs.ctx,
+                self.context.instance.allocator().ctx,
+            )
         })
+        .to_result()
+        .map_err(Into::into)
     }
 }
 

--- a/tests/mixed.mlir
+++ b/tests/mixed.mlir
@@ -1,0 +1,13 @@
+module @mixed {
+  func.func @is_positive(%arg0: tensor<4xf32>) -> tensor<4xi1> {
+    %zero = arith.constant dense<0.0> : tensor<4xf32>
+    %0 = arith.cmpf ogt, %arg0, %zero : tensor<4xf32>
+    return %0 : tensor<4xi1>
+  }
+
+  func.func @select_masked(%values: tensor<4xf32>, %mask: tensor<4xi1>) -> tensor<4xf32> {
+    %zero = arith.constant dense<0.0> : tensor<4xf32>
+    %0 = arith.select %mask, %values, %zero : tensor<4xi1>, tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,401 +1,104 @@
 #![cfg(feature = "runtime")]
 
-use eerie::runtime::{
-    self,
-    error::RuntimeError,
-    hal::{Buffer, BufferMapping, BufferParams, BufferView, ElementType, Encoding},
-    vm::{FunctionLinkage, List, ToRef, ToValue, Undefined, Value},
-};
+use eerie::runtime::{BufferView, Driver, Runtime, RuntimeError, Value};
 use half::f16;
-use log::info;
 use test_log::test;
 
-fn local_sync_device() -> (
-    runtime::hal::DriverRegistry,
-    runtime::hal::Driver,
-    runtime::hal::Device,
-) {
-    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver("local-sync").unwrap();
-    let device = driver.create_default_device().unwrap();
-    (registry, driver, device)
-}
-
 #[test]
-fn test_instance() {
-    runtime::vm::Instance::global().unwrap();
-}
-
-#[test]
-fn test_context_with_hal_module() {
-    let instance = runtime::vm::Instance::global().unwrap();
-    let (_registry, _driver, device) = local_sync_device();
-    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
-    runtime::vm::Context::with_modules(&instance, &[&hal_module]).unwrap();
-}
-
-#[test]
-fn device_metadata() {
-    let (_registry, driver, device) = local_sync_device();
-    let devices = driver.available_devices().unwrap();
-    assert!(!devices.is_empty());
-    assert_eq!(devices[0].ordinal, 0);
-    assert!(!devices[0].name.is_empty() || !devices[0].path.is_empty());
-    assert!(!device.id().is_empty());
-    device.capabilities().unwrap();
-    assert!(device
-        .query_i64("eerie.missing.query.category", "missing-key")
-        .is_err());
-    device.trim().unwrap();
-}
-
-#[test]
-fn dynamic_list() {
-    let instance = runtime::vm::Instance::global().unwrap();
-    let mut list = List::<Value<i32>>::new(4, &instance).unwrap();
-    list.push_value(1.to_value()).unwrap();
-    list.push_value(2.to_value()).unwrap();
-    list.push_value(3.to_value()).unwrap();
-    list.push_value(4.to_value()).unwrap();
-    let val = list.get_value::<i32>(0).unwrap();
-    drop(list);
-    assert_eq!(val.get(), 1);
-}
-
-#[test]
-fn ref_list() {
-    let instance = runtime::vm::Instance::global().unwrap();
-    let (_registry, _driver, device) = local_sync_device();
-    let mut list = List::<Undefined>::new(4, &instance).unwrap();
-    let buffer = BufferView::<f32>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[1.0, 2.0, 3.0, 4.0],
-    )
-    .unwrap();
-    info!("buffer: {:?}", buffer);
-    let buffer_ref = buffer.to_ref(&instance).unwrap();
-    list.push_ref(&buffer_ref).unwrap();
-    list.push_ref(&buffer_ref).unwrap();
-    let buffer_ref_2 = list.get_ref::<BufferView<f32>>(0).unwrap();
-    let buffer_2 = buffer_ref_2.to_buffer_view().unwrap();
-    info!("buffer_ref_2: {:?}", buffer_2);
-
-    let mapping = BufferMapping::map_read(&buffer_2).unwrap();
-    info!("mapping: {:?}", mapping.data());
-}
-
-#[test]
-fn fp16_buffer() {
-    let (_registry, _driver, device) = local_sync_device();
-    let buffer = BufferView::<f16>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[
-            f16::from_f32(1.0),
-            f16::from_f32(2.0),
-            f16::from_f32(3.0),
-            f16::from_f32(4.0),
-        ],
-    )
-    .unwrap();
-
-    let mapping = BufferMapping::map_read(&buffer).unwrap();
-    assert_eq!(
-        mapping.data(),
-        &[
-            f16::from_f32(1.0),
-            f16::from_f32(2.0),
-            f16::from_f32(3.0),
-            f16::from_f32(4.0)
-        ]
-    );
-}
-
-#[test]
-fn bool_buffer_roundtrip_read_write_copy_and_mapping() {
-    let (_registry, _driver, device) = local_sync_device();
-    let buffer = BufferView::<bool>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[true, false, true, false],
-    )
-    .unwrap();
-
-    assert_eq!(buffer.element_type(), ElementType::Bool8);
-    assert_eq!(buffer.element_size(), core::mem::size_of::<bool>());
-    assert_eq!(
-        buffer.read_to_vec(&device).unwrap(),
-        vec![true, false, true, false]
-    );
-
-    let mapping = BufferMapping::map_read(&buffer).unwrap();
-    assert_eq!(mapping.data(), &[true, false, true, false]);
-    drop(mapping);
-
-    buffer
-        .write_from_slice(&device, &[false, true, false, true])
+fn buffer_view_metadata_and_readback() {
+    let runtime = Runtime::new(Driver::LocalSync).unwrap();
+    let buffer = runtime
+        .buffer_view(&[2, 2], &[1.0_f32, 2.0, 3.0, 4.0])
         .unwrap();
-    assert_eq!(
-        buffer.read_to_vec(&device).unwrap(),
-        vec![false, true, false, true]
-    );
 
-    let target = BufferView::<bool>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[false, false, false, false],
-    )
-    .unwrap();
-    buffer.copy_to(&device, &target).unwrap();
-    assert_eq!(
-        target.read_to_vec(&device).unwrap(),
-        vec![false, true, false, true]
-    );
-}
-
-#[test]
-fn bool_buffer_rejects_invalid_bool8_bytes() {
-    let (_registry, _driver, device) = local_sync_device();
-    let buffer = Buffer::allocate(&device, 1, BufferParams::default()).unwrap();
-    let raw_view = BufferView::<u8>::from_buffer(&buffer, &[1], Encoding::DenseRowMajor).unwrap();
-    raw_view.write_from_slice(&device, &[2]).unwrap();
-
-    let bool_view =
-        BufferView::<bool>::from_buffer(&buffer, &[1], Encoding::DenseRowMajor).unwrap();
-    let err = bool_view.read_to_vec(&device).unwrap_err();
-    assert!(format!("{err}").contains("invalid Bool8 value 2"));
-
-    let err = match BufferMapping::map_read(&bool_view) {
-        Ok(_) => panic!("invalid Bool8 mapping succeeded"),
-        Err(err) => err,
-    };
-    assert!(format!("{err}").contains("invalid Bool8 value 2"));
-}
-
-#[test]
-fn buffer_metadata() {
-    let (_registry, _driver, device) = local_sync_device();
-    let buffer = BufferView::<f32>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[1.0, 2.0, 3.0, 4.0],
-    )
-    .unwrap();
-
-    assert_eq!(buffer.rank(), 2);
     assert_eq!(buffer.shape(), vec![2, 2]);
-    assert_eq!(buffer.dim(0), 2);
-    assert_eq!(buffer.dim(1), 2);
-    assert_eq!(buffer.element_count(), 4);
-    assert_eq!(buffer.element_size(), core::mem::size_of::<f32>());
-    assert_eq!(buffer.element_type(), ElementType::Float32);
-    assert_eq!(buffer.encoding(), Encoding::DenseRowMajor);
+    assert_eq!(buffer.read().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
 }
 
 #[test]
-fn raw_buffer_allocation_and_view() {
-    let (_registry, _driver, device) = local_sync_device();
-    let buffer = Buffer::allocate(
-        &device,
-        4 * core::mem::size_of::<f32>(),
-        BufferParams::default(),
-    )
-    .unwrap();
-    assert_eq!(buffer.byte_offset(), 0);
-    assert_eq!(buffer.byte_length(), 4 * core::mem::size_of::<f32>());
-    assert!(buffer.allocation_size() >= buffer.byte_length());
-    assert_ne!(buffer.memory_type(), 0);
-    assert_ne!(buffer.allowed_access(), 0);
-    assert_ne!(buffer.allowed_usage(), 0);
+fn scalar_buffer_view_has_empty_shape() {
+    let runtime = Runtime::new(Driver::LocalSync).unwrap();
+    let buffer = runtime.buffer_view(&[], &[42.0_f32]).unwrap();
 
-    let view = BufferView::<f32>::from_buffer(&buffer, &[4], Encoding::DenseRowMajor).unwrap();
-    let raw_buffer = view.raw_buffer();
-    assert_eq!(raw_buffer.byte_length(), buffer.byte_length());
-    assert_eq!(raw_buffer.memory_type(), buffer.memory_type());
-    assert_eq!(raw_buffer.allowed_access(), buffer.allowed_access());
-    assert_eq!(raw_buffer.allowed_usage(), buffer.allowed_usage());
-
-    view.write_from_slice(&device, &[1.0, 2.0, 3.0, 4.0])
-        .unwrap();
-    assert_eq!(view.read_to_vec(&device).unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
-
-    let subspan = buffer.subspan(0, 2 * core::mem::size_of::<f32>()).unwrap();
-    assert_eq!(subspan.byte_length(), 2 * core::mem::size_of::<f32>());
+    assert_eq!(buffer.shape(), Vec::<usize>::new());
+    assert_eq!(buffer.read().unwrap(), vec![42.0]);
 }
 
 #[test]
 fn buffer_shape_mismatch_is_rejected() {
-    let (_registry, _driver, device) = local_sync_device();
-    let err = BufferView::<f32>::from_host(
-        &device,
-        &[2, 3],
-        Encoding::DenseRowMajor,
-        &[1.0, 2.0, 3.0, 4.0],
-    )
-    .unwrap_err();
+    let runtime = Runtime::new(Driver::LocalSync).unwrap();
+    let err = runtime
+        .buffer_view(&[2, 3], &[1.0_f32, 2.0, 3.0, 4.0])
+        .unwrap_err();
 
     assert!(matches!(err, RuntimeError::InvalidArgument(_)));
 }
 
 #[test]
-fn buffer_view_read_write_and_copy() {
-    let (_registry, _driver, device) = local_sync_device();
-    let buffer = BufferView::<f32>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[1.0, 2.0, 3.0, 4.0],
-    )
-    .unwrap();
-    assert_eq!(buffer.shape(), vec![2, 2]);
-    assert_eq!(
-        buffer.read_to_vec(&device).unwrap(),
-        vec![1.0, 2.0, 3.0, 4.0]
-    );
+fn fp16_buffer_roundtrip() {
+    let runtime = Runtime::new(Driver::LocalSync).unwrap();
+    let input = [
+        f16::from_f32(1.0),
+        f16::from_f32(2.0),
+        f16::from_f32(3.0),
+        f16::from_f32(4.0),
+    ];
+    let buffer = runtime.buffer_view(&[2, 2], &input).unwrap();
 
-    buffer
-        .write_from_slice(&device, &[5.0, 6.0, 7.0, 8.0])
-        .unwrap();
-    assert_eq!(
-        buffer.read_to_vec(&device).unwrap(),
-        vec![5.0, 6.0, 7.0, 8.0]
-    );
-
-    let target = BufferView::<f32>::from_host(
-        &device,
-        &[2, 2],
-        Encoding::DenseRowMajor,
-        &[0.0, 0.0, 0.0, 0.0],
-    )
-    .unwrap();
-    buffer.copy_to(&device, &target).unwrap();
-    assert_eq!(
-        target.read_to_vec(&device).unwrap(),
-        vec![5.0, 6.0, 7.0, 8.0]
-    );
+    assert_eq!(buffer.read().unwrap(), input);
 }
 
 #[test]
-fn append_module_from_vmvx_fixture() {
-    let vmfb = include_bytes!("mul_vmvx.vmfb");
-    let output = run_mul(vmfb, "local-sync");
+fn bool_buffer_roundtrip() {
+    let runtime = Runtime::new(Driver::LocalSync).unwrap();
+    let buffer = runtime
+        .buffer_view(&[2, 2], &[true, false, true, false])
+        .unwrap();
+
+    assert_eq!(buffer.read().unwrap(), vec![true, false, true, false]);
+}
+
+#[test]
+fn fixture_vmfb_invokes_buffer_views() {
+    let output = run_mul(include_bytes!("mul_vmvx.vmfb"), Driver::LocalSync);
     assert_eq!(output[0], 0.0);
     assert_eq!(output[7], 49.0);
     assert_eq!(output[99], 9801.0);
 }
 
 #[test]
-fn function_metadata_and_buffer_view_invoke() {
-    let vmfb = include_bytes!("mul_vmvx.vmfb");
-    let instance = runtime::vm::Instance::global().unwrap();
-    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver("local-sync").unwrap();
-    let device = driver.create_default_device().unwrap();
-    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
-    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
-    let context =
-        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
-    let function = context.resolve_function("arithmetic.simple_mul").unwrap();
-
-    assert_eq!(bytecode_module.name(), "arithmetic");
-    let module_signature = bytecode_module.signature();
-    assert!(module_signature.export_function_count >= 1);
-    assert!(bytecode_module.lookup_attr("missing.module.attr").is_none());
-    assert!(bytecode_module
-        .attr(module_signature.attr_count)
-        .unwrap()
-        .is_none());
-    let function_ref = bytecode_module
-        .lookup_export_function("simple_mul")
-        .unwrap();
-    assert_eq!(function_ref.name(), "simple_mul");
-    assert_eq!(function_ref.signature().argument_count, 2);
-    assert!(function_ref.lookup_attr("missing.function.attr").is_none());
-
-    let function_ref = bytecode_module
-        .lookup_function("simple_mul", FunctionLinkage::Export)
-        .unwrap();
-    assert_eq!(function_ref.name(), "simple_mul");
-
-    assert_eq!(function.name(), "simple_mul");
-    let signature = function.signature();
-    assert_eq!(signature.argument_count, 2);
-    assert_eq!(signature.result_count, 1);
-    assert!(function.lookup_attr("missing.function.attr").is_none());
-
-    let input_data = Vec::from_iter((0..100).map(|i| i as f32));
-    let input = BufferView::<f32>::from_host(
-        &device,
-        &[100],
-        Encoding::DenseRowMajor,
-        input_data.as_slice(),
-    )
-    .unwrap();
-    let output = invoke_mul_function(&function, &instance, &device, &input);
-    assert_eq!(output[0], 0.0);
-    assert_eq!(output[7], 49.0);
-    assert_eq!(output[99], 9801.0);
-}
-
-#[test]
-fn invoke_uses_shared_hal_type_registration() {
-    let vmfb = include_bytes!("mul_vmvx.vmfb");
-    let instance = runtime::vm::Instance::global().unwrap();
-    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver("local-sync").unwrap();
-    let device = driver.create_default_device().unwrap();
-    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
-    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
-    let context =
-        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
-    let function = context.resolve_function("arithmetic.simple_mul").unwrap();
-
-    let input_data = Vec::from_iter((0..100).map(|i| i as f32));
-    let input = BufferView::<f32>::from_host(
-        &device,
-        &[100],
-        Encoding::DenseRowMajor,
-        input_data.as_slice(),
-    )
-    .unwrap();
-    let mut input_list = List::<Undefined>::new(2, &instance).unwrap();
-    input_list
-        .push_ref(&input.to_ref(&instance).unwrap())
-        .unwrap();
-    input_list
-        .push_ref(&input.to_ref(&instance).unwrap())
-        .unwrap();
-
-    let mut output_list = List::<Undefined>::new(1, &instance).unwrap();
-    function.invoke(&input_list, &mut output_list).unwrap();
-    let output = output_list
-        .get_ref::<BufferView<f32>>(0)
-        .unwrap()
-        .to_buffer_view()
-        .unwrap()
-        .read_to_vec(&device)
-        .unwrap();
-    assert_eq!(output[0], 0.0);
-    assert_eq!(output[7], 49.0);
-    assert_eq!(output[99], 9801.0);
-}
-
-#[test]
-fn parallel_invocations_share_vm_instance() {
+fn parallel_program_invocations() {
+    let vmfb = std::sync::Arc::new(include_bytes!("mul_vmvx.vmfb").to_vec());
+    let thread_count = std::env::var("EERIE_STRESS_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(16);
+    let iterations = std::env::var("EERIE_STRESS_ITERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(8);
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(thread_count));
     let mut threads = Vec::new();
-    for _ in 0..2 {
-        threads.push(std::thread::spawn(|| {
-            let vmfb = include_bytes!("mul_vmvx.vmfb");
-            let output = run_mul(vmfb, "local-sync");
-            assert_eq!(output[0], 0.0);
-            assert_eq!(output[7], 49.0);
-            assert_eq!(output[99], 9801.0);
+
+    for _ in 0..thread_count {
+        let vmfb = vmfb.clone();
+        let barrier = barrier.clone();
+        threads.push(std::thread::spawn(move || {
+            let runtime = Runtime::new(Driver::LocalSync).unwrap();
+            let program = runtime.load_vmfb(&vmfb).unwrap();
+            let function = program.function("arithmetic.simple_mul").unwrap();
+            let input_data = Vec::from_iter((0..100).map(|i| i as f32));
+            let lhs = runtime.buffer_view(&[100], input_data.as_slice()).unwrap();
+            let rhs = runtime.buffer_view(&[100], input_data.as_slice()).unwrap();
+
+            barrier.wait();
+            for _ in 0..iterations {
+                let output = take_output::<f32>(function.invoke([&lhs, &rhs]).unwrap());
+                let output = output.read().unwrap();
+                assert_eq!(output[0], 0.0);
+                assert_eq!(output[7], 49.0);
+                assert_eq!(output[99], 9801.0);
+            }
         }));
     }
 
@@ -404,94 +107,111 @@ fn parallel_invocations_share_vm_instance() {
     }
 }
 
-fn run_mul(vmfb: &[u8], driver_name: &str) -> Vec<f32> {
-    let instance = runtime::vm::Instance::global().unwrap();
-    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver(driver_name).unwrap();
-    let device = driver.create_default_device().unwrap();
-    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
-    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
-    let context =
-        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
-    let function = context.resolve_function("arithmetic.simple_mul").unwrap();
+#[test]
+fn parallel_runtime_stack_churn() {
+    let vmfb = std::sync::Arc::new(include_bytes!("mul_vmvx.vmfb").to_vec());
+    let thread_count = std::env::var("EERIE_CHURN_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(16);
+    let iterations = std::env::var("EERIE_CHURN_ITERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(8);
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(thread_count));
+    let mut threads = Vec::new();
 
+    for _ in 0..thread_count {
+        let vmfb = vmfb.clone();
+        let barrier = barrier.clone();
+        threads.push(std::thread::spawn(move || {
+            barrier.wait();
+            for _ in 0..iterations {
+                let output = run_mul(&vmfb, Driver::LocalSync);
+                assert_eq!(output[0], 0.0);
+                assert_eq!(output[7], 49.0);
+                assert_eq!(output[99], 9801.0);
+            }
+        }));
+    }
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}
+
+fn run_mul(vmfb: &[u8], driver: Driver) -> Vec<f32> {
+    let runtime = Runtime::new(driver).unwrap();
+    let program = runtime.load_vmfb(vmfb).unwrap();
     let input_data = Vec::from_iter((0..100).map(|i| i as f32));
-    let input = BufferView::<f32>::from_host(
-        &device,
-        &[100],
-        Encoding::DenseRowMajor,
-        input_data.as_slice(),
-    )
-    .unwrap();
-
-    invoke_mul_function(&function, &instance, &device, &input)
+    let lhs = runtime.buffer_view(&[100], input_data.as_slice()).unwrap();
+    let rhs = runtime.buffer_view(&[100], input_data.as_slice()).unwrap();
+    let function = program.function("arithmetic.simple_mul").unwrap();
+    let output = take_output::<f32>(function.invoke([&lhs, &rhs]).unwrap());
+    output.read().unwrap()
 }
 
-fn invoke_mul_function(
-    function: &runtime::vm::Function,
-    instance: &runtime::vm::Instance,
-    device: &runtime::hal::Device,
-    input: &BufferView<f32>,
-) -> Vec<f32> {
-    let mut input_list = List::<Undefined>::new(2, instance).unwrap();
-    input_list
-        .push_ref(&input.to_ref(instance).unwrap())
+#[cfg(feature = "compiler")]
+fn run_bool_not(vmfb: &[u8], driver: Driver) -> Vec<bool> {
+    let runtime = Runtime::new(driver).unwrap();
+    let program = runtime.load_vmfb(vmfb).unwrap();
+    let input = runtime
+        .buffer_view(&[4], &[true, false, false, true])
         .unwrap();
-    input_list
-        .push_ref(&input.to_ref(instance).unwrap())
-        .unwrap();
-    let mut output_list = List::<Undefined>::new(1, instance).unwrap();
-    function.invoke(&input_list, &mut output_list).unwrap();
-    let output_ref = output_list.get_ref::<BufferView<f32>>(0).unwrap();
-    output_ref
-        .to_buffer_view()
-        .unwrap()
-        .read_to_vec(&device)
-        .unwrap()
+    let function = program.function("bools.logical_not").unwrap();
+    let output = take_output::<bool>(function.invoke([&input]).unwrap());
+    output.read().unwrap()
 }
 
-fn run_bool_not(vmfb: &[u8], driver_name: &str) -> Vec<bool> {
-    let instance = runtime::vm::Instance::global().unwrap();
-    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver(driver_name).unwrap();
-    let device = driver.create_default_device().unwrap();
-    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
-    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
-    let context =
-        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
-    let function = context.resolve_function("bools.logical_not").unwrap();
-
-    let input = BufferView::<bool>::from_host(
-        &device,
-        &[4],
-        Encoding::DenseRowMajor,
-        &[true, false, false, true],
-    )
-    .unwrap();
-
-    let mut input_list = List::<Undefined>::new(1, &instance).unwrap();
-    input_list
-        .push_ref(&input.to_ref(&instance).unwrap())
+#[cfg(feature = "compiler")]
+fn run_is_positive(vmfb: &[u8], driver: Driver) -> Vec<bool> {
+    let runtime = Runtime::new(driver).unwrap();
+    let program = runtime.load_vmfb(vmfb).unwrap();
+    let input = runtime
+        .buffer_view(&[4], &[-1.0_f32, 0.0, 2.0, 3.5])
         .unwrap();
-    let mut output_list = List::<Undefined>::new(1, &instance).unwrap();
-    function.invoke(&input_list, &mut output_list).unwrap();
-    output_list
-        .get_ref::<BufferView<bool>>(0)
-        .unwrap()
-        .to_buffer_view()
-        .unwrap()
-        .read_to_vec(&device)
-        .unwrap()
+    let function = program.function("mixed.is_positive").unwrap();
+    let output = take_output::<bool>(function.invoke([&input]).unwrap());
+    output.read().unwrap()
+}
+
+#[cfg(feature = "compiler")]
+fn run_select_masked(vmfb: &[u8], driver: Driver) -> Vec<f32> {
+    let runtime = Runtime::new(driver).unwrap();
+    let program = runtime.load_vmfb(vmfb).unwrap();
+    let values = runtime
+        .buffer_view(&[4], &[1.0_f32, 2.0, 3.0, 4.0])
+        .unwrap();
+    let mask = runtime
+        .buffer_view(&[4], &[true, false, true, false])
+        .unwrap();
+    let function = program.function("mixed.select_masked").unwrap();
+    let output = take_output::<f32>(
+        function
+            .invoke(vec![Value::from(&values), Value::from(&mask)])
+            .unwrap(),
+    );
+    output.read().unwrap()
+}
+
+fn take_output<T>(mut outputs: Vec<Value>) -> BufferView<T>
+where
+    T: eerie::runtime::BufferElement,
+    BufferView<T>: TryFrom<Value, Error = RuntimeError>,
+{
+    assert_eq!(outputs.len(), 1);
+    outputs.remove(0).try_into().unwrap()
 }
 
 #[cfg(feature = "compiler")]
 mod integration_tests {
     use eerie::compiler;
+    use eerie::runtime::Driver;
     use log::info;
     use std::path::Path;
     use std::sync::Mutex;
 
-    use super::{run_bool_not, run_mul};
+    use super::{run_bool_not, run_is_positive, run_mul, run_select_masked};
 
     static COMPILER: Mutex<Option<compiler::Compiler>> = Mutex::new(None);
 
@@ -509,6 +229,10 @@ mod integration_tests {
 
     fn compile_bool_not(target_backend: &str) -> Vec<u8> {
         compile_mlir(target_backend, Path::new("tests/bool.mlir"))
+    }
+
+    fn compile_mixed(target_backend: &str) -> Vec<u8> {
+        compile_mlir(target_backend, Path::new("tests/mixed.mlir"))
     }
 
     fn compile_mlir(target_backend: &str, path: &Path) -> Vec<u8> {
@@ -539,7 +263,7 @@ mod integration_tests {
     #[test]
     fn append_module() {
         let vmfb = compile_mul("llvm-cpu");
-        let output = run_mul(&vmfb, "local-sync");
+        let output = run_mul(&vmfb, Driver::LocalSync);
         info!("Output: {:?}", output);
         assert_eq!(output[0], 0.0);
         assert_eq!(output[7], 49.0);
@@ -549,8 +273,22 @@ mod integration_tests {
     #[test]
     fn bool_buffer_view_invoke() {
         let vmfb = compile_bool_not("llvm-cpu");
-        let output = run_bool_not(&vmfb, "local-sync");
+        let output = run_bool_not(&vmfb, Driver::LocalSync);
         assert_eq!(output, vec![false, true, true, false]);
+    }
+
+    #[test]
+    fn mixed_dtype_invoke() {
+        let vmfb = compile_mixed("llvm-cpu");
+        let output = run_is_positive(&vmfb, Driver::LocalSync);
+        assert_eq!(output, vec![false, false, true, true]);
+    }
+
+    #[test]
+    fn mixed_input_dtype_invoke() {
+        let vmfb = compile_mixed("llvm-cpu");
+        let output = run_select_masked(&vmfb, Driver::LocalSync);
+        assert_eq!(output, vec![1.0, 0.0, 3.0, 0.0]);
     }
 
     #[test]
@@ -559,10 +297,13 @@ mod integration_tests {
             return;
         }
 
-        let vmfb = compile_mul("metal-spirv");
-        let output = run_mul(&vmfb, "metal");
-        assert_eq!(output[0], 0.0);
-        assert_eq!(output[7], 49.0);
-        assert_eq!(output[99], 9801.0);
+        #[cfg(target_os = "macos")]
+        {
+            let vmfb = compile_mul("metal-spirv");
+            let output = run_mul(&vmfb, Driver::Metal);
+            assert_eq!(output[0], 0.0);
+            assert_eq!(output[7], 49.0);
+            assert_eq!(output[99], 9801.0);
+        }
     }
 }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -23,12 +23,12 @@ fn local_sync_device() -> (
 
 #[test]
 fn test_instance() {
-    runtime::vm::Instance::new().unwrap();
+    runtime::vm::Instance::global().unwrap();
 }
 
 #[test]
 fn test_context_with_hal_module() {
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let (_registry, _driver, device) = local_sync_device();
     let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
     runtime::vm::Context::with_modules(&instance, &[&hal_module]).unwrap();
@@ -51,7 +51,7 @@ fn device_metadata() {
 
 #[test]
 fn dynamic_list() {
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let mut list = List::<Value<i32>>::new(4, &instance).unwrap();
     list.push_value(1.to_value()).unwrap();
     list.push_value(2.to_value()).unwrap();
@@ -64,7 +64,7 @@ fn dynamic_list() {
 
 #[test]
 fn ref_list() {
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let (_registry, _driver, device) = local_sync_device();
     let mut list = List::<Undefined>::new(4, &instance).unwrap();
     let buffer = BufferView::<f32>::from_host(
@@ -293,7 +293,7 @@ fn append_module_from_vmvx_fixture() {
 #[test]
 fn function_metadata_and_buffer_view_invoke() {
     let vmfb = include_bytes!("mul_vmvx.vmfb");
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
     let driver = registry.create_driver("local-sync").unwrap();
     let device = driver.create_default_device().unwrap();
@@ -344,38 +344,9 @@ fn function_metadata_and_buffer_view_invoke() {
 }
 
 #[test]
-fn invoke_after_newer_instance_rebinds_hal_types() {
+fn invoke_uses_shared_hal_type_registration() {
     let vmfb = include_bytes!("mul_vmvx.vmfb");
-    let instance = runtime::vm::Instance::new().unwrap();
-    let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
-    let driver = registry.create_driver("local-sync").unwrap();
-    let device = driver.create_default_device().unwrap();
-    let hal_module = runtime::vm::Module::hal(&instance, &device).unwrap();
-    let bytecode_module = runtime::vm::Module::bytecode(&instance, vmfb).unwrap();
-    let context =
-        runtime::vm::Context::with_modules(&instance, &[&hal_module, &bytecode_module]).unwrap();
-    let function = context.resolve_function("arithmetic.simple_mul").unwrap();
-
-    let _newer_instance = runtime::vm::Instance::new().unwrap();
-
-    let input_data = Vec::from_iter((0..100).map(|i| i as f32));
-    let input = BufferView::<f32>::from_host(
-        &device,
-        &[100],
-        Encoding::DenseRowMajor,
-        input_data.as_slice(),
-    )
-    .unwrap();
-    let output = invoke_mul_function(&function, &instance, &device, &input);
-    assert_eq!(output[0], 0.0);
-    assert_eq!(output[7], 49.0);
-    assert_eq!(output[99], 9801.0);
-}
-
-#[test]
-fn invoke_rebinds_prepared_hal_argument_refs() {
-    let vmfb = include_bytes!("mul_vmvx.vmfb");
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
     let driver = registry.create_driver("local-sync").unwrap();
     let device = driver.create_default_device().unwrap();
@@ -401,8 +372,6 @@ fn invoke_rebinds_prepared_hal_argument_refs() {
         .push_ref(&input.to_ref(&instance).unwrap())
         .unwrap();
 
-    let _newer_instance = runtime::vm::Instance::new().unwrap();
-
     let mut output_list = List::<Undefined>::new(1, &instance).unwrap();
     function.invoke(&input_list, &mut output_list).unwrap();
     let output = output_list
@@ -418,7 +387,7 @@ fn invoke_rebinds_prepared_hal_argument_refs() {
 }
 
 #[test]
-fn parallel_instance_invocations_rebind_hal_types() {
+fn parallel_invocations_share_vm_instance() {
     let mut threads = Vec::new();
     for _ in 0..2 {
         threads.push(std::thread::spawn(|| {
@@ -436,7 +405,7 @@ fn parallel_instance_invocations_rebind_hal_types() {
 }
 
 fn run_mul(vmfb: &[u8], driver_name: &str) -> Vec<f32> {
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
     let driver = registry.create_driver(driver_name).unwrap();
     let device = driver.create_default_device().unwrap();
@@ -482,7 +451,7 @@ fn invoke_mul_function(
 }
 
 fn run_bool_not(vmfb: &[u8], driver_name: &str) -> Vec<bool> {
-    let instance = runtime::vm::Instance::new().unwrap();
+    let instance = runtime::vm::Instance::global().unwrap();
     let registry = runtime::hal::DriverRegistry::with_available_drivers().unwrap();
     let driver = registry.create_driver(driver_name).unwrap();
     let device = driver.create_default_device().unwrap();


### PR DESCRIPTION
## Summary

- Add `runtime::vm::Instance::global()` as the safe API for acquiring a retained handle to the process-wide VM instance.
- Restore `Clone` for `Instance` as the idiomatic retain/release operation over the IREE refcounted handle.
- Remove the HAL ref rebinding workaround.
- Resolve HAL VM type adapters against the shared instance before VM invocation, so native HAL imports check refs against the same type ids used by Rust-created VM refs.
- Document that the shared root VM instance is retained for the process/program lifetime.

## Why

IREE expects VM instances to be reused across contexts, and HAL type registration uses process-global adapter state. Modeling the safe Rust runtime API as a shared process-wide instance avoids the multi-instance HAL type registration race tracked in https://github.com/iree-org/iree/issues/24615 and fixes gmmyung/eerie#28.

## Validation

- `nix develop --command cargo fmt --check`
- `nix develop --command cargo check --no-default-features --features runtime`
- `nix develop --command cargo test -vv --release`
- repeated `nix develop --command cargo test --release` x3
