### PR TITLE
[codex] Gate half runtime types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ repository = "https://github.com/gmmyung/eerie"
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["std", "runtime"]
+features = ["std", "runtime", "half"]
 
 [dependencies]
 eerie-sys = { path = "eerie-sys", version = "0.3.2", default-features = false }
 thiserror = { version = "2.0", optional = true }
 log = "0.4"
-half = { version = "2.7", default-features = false }
+half = { version = "2.7", default-features = false, optional = true }
 critical-section = { version = "1.2", optional = true }
 libm = { version = "0.2", default-features = false, optional = true }
 tinyrlibc = { version = "0.5.1", default-features = false, features = [
@@ -49,6 +49,7 @@ default = ["runtime", "compiler", "std"]
 runtime = ["eerie-sys/runtime", "dep:critical-section", "dep:libm", "dep:tinyrlibc"]
 compiler = ["eerie-sys/compiler", "std"]
 std = ["dep:thiserror", "eerie-sys/std"]
+half = ["dep:half"]
 cuda = ["eerie-sys/cuda"]
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ input buffers through `Runtime::buffer_view`, resolve functions through
 `Program::function`, invoke with `Function::invoke`, convert returned `Value`s
 into typed `BufferView<T>` handles, and read outputs with `BufferView::read`.
 Supported `BufferView<T>` element types are `bool` (IREE Bool8), signed and
-unsigned 8/16/32/64-bit integers, `f16`, `bf16`, `f32`, and `f64`.
+unsigned 8/16/32/64-bit integers, `f32`, and `f64`. The `half` feature adds
+`f16` and `bf16` support through the optional `half` crate dependency.
 
 Runtime driver selection uses `runtime::Driver`, not raw driver strings.
 `Driver::LocalSync` is always available. `Driver::LocalTask` is available with

--- a/src/runtime/hal.rs
+++ b/src/runtime/hal.rs
@@ -7,6 +7,7 @@ use core::{
 };
 
 use eerie_sys::runtime as sys;
+#[cfg(feature = "half")]
 use half::{bf16, f16};
 use log::debug;
 
@@ -278,10 +279,12 @@ impl_buffer_element!(
     f64,
     sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_64
 );
+#[cfg(feature = "half")]
 impl_buffer_element!(
     f16,
     sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16
 );
+#[cfg(feature = "half")]
 impl_buffer_element!(
     bf16,
     sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16
@@ -519,9 +522,11 @@ pub enum Value {
     I16(BufferView<i16>),
     I32(BufferView<i32>),
     I64(BufferView<i64>),
+    #[cfg(feature = "half")]
     F16(BufferView<f16>),
     F32(BufferView<f32>),
     F64(BufferView<f64>),
+    #[cfg(feature = "half")]
     Bf16(BufferView<bf16>),
 }
 
@@ -537,9 +542,11 @@ impl Value {
             Value::I16(_) => "i16",
             Value::I32(_) => "i32",
             Value::I64(_) => "i64",
+            #[cfg(feature = "half")]
             Value::F16(_) => "f16",
             Value::F32(_) => "f32",
             Value::F64(_) => "f64",
+            #[cfg(feature = "half")]
             Value::Bf16(_) => "bf16",
         }
     }
@@ -577,6 +584,7 @@ impl Value {
             sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_INT_64 => Ok(Value::I64(unsafe {
                 BufferView::from_raw_retained(ctx, device)
             })),
+            #[cfg(feature = "half")]
             sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_FLOAT_16 => {
                 Ok(Value::F16(unsafe {
                     BufferView::from_raw_retained(ctx, device)
@@ -592,6 +600,7 @@ impl Value {
                     BufferView::from_raw_retained(ctx, device)
                 }))
             }
+            #[cfg(feature = "half")]
             sys::iree_hal_element_types_t_IREE_HAL_ELEMENT_TYPE_BFLOAT_16 => {
                 Ok(Value::Bf16(unsafe {
                     BufferView::from_raw_retained(ctx, device)
@@ -645,7 +654,9 @@ impl_value_conversion!(I8, i8, "i8");
 impl_value_conversion!(I16, i16, "i16");
 impl_value_conversion!(I32, i32, "i32");
 impl_value_conversion!(I64, i64, "i64");
+#[cfg(feature = "half")]
 impl_value_conversion!(F16, f16, "f16");
 impl_value_conversion!(F32, f32, "f32");
 impl_value_conversion!(F64, f64, "f64");
+#[cfg(feature = "half")]
 impl_value_conversion!(Bf16, bf16, "bf16");

--- a/src/runtime/high_level.rs
+++ b/src/runtime/high_level.rs
@@ -129,9 +129,11 @@ fn push_value(
         Value::I16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
         Value::I32(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
         Value::I64(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        #[cfg(feature = "half")]
         Value::F16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
         Value::F32(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
         Value::F64(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
+        #[cfg(feature = "half")]
         Value::Bf16(buffer) => list.push_ref(&buffer.to_ref(instance)?)?,
     }
     Ok(())

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "runtime")]
 
 use eerie::runtime::{BufferView, Driver, Runtime, RuntimeError, Value};
+#[cfg(feature = "half")]
 use half::f16;
 use test_log::test;
 
@@ -34,6 +35,7 @@ fn buffer_shape_mismatch_is_rejected() {
     assert!(matches!(err, RuntimeError::InvalidArgument(_)));
 }
 
+#[cfg(feature = "half")]
 #[test]
 fn fp16_buffer_roundtrip() {
     let runtime = Runtime::new(Driver::LocalSync).unwrap();


### PR DESCRIPTION
## Summary

- Makes the `half` crate an optional dependency behind the `half` feature.
- Gates `f16`/`bf16` runtime `BufferView`/`Value` support behind that feature.
- Keeps docs.rs building optional half APIs by enabling `half` in docs metadata.
- Updates README wording so half support is documented as feature-gated.

## Validation

- `nix develop --command cargo fmt --check`
- `nix develop --command cargo check --no-default-features --features runtime,std`
- `nix develop --command sh -lc 'cargo tree --no-default-features --features runtime,std | rg "(^| )half v" || true'` produced no `half` dependency output
- `nix develop --command cargo test --features runtime,std`
- `nix develop --command cargo test --features runtime,std,half`
- `nix develop --command cargo check --no-default-features --features runtime,std,half`
- `nix develop --command cargo clippy --all-targets --features runtime,std,half -- -D warnings`
- `nix develop --command cargo check --no-default-features --features runtime`
- `nix develop --command cargo doc --no-deps --no-default-features --features runtime,std,half`
