### PR TITLE
[codex] Add direnv environment file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .vscode
 .venv
 .cargo
+.direnv


### PR DESCRIPTION
## Summary

- Add `.envrc` with `use flake` so direnv loads the project flake dev shell automatically.
- Ignore `.direnv` local cache files.

## Validation

- Ran `direnv allow` in `~/eerie`.
- Verified `direnv export bash` loads the flake dev shell on x86_64-linux and exposes Cargo/Clang-related environment variables.
- Verified `cargo test --features compiler,runtime,std` passes on x86_64-linux after enabling `nix-ld` on the NixOS test VM.
- Verified `cargo test --no-default-features --features runtime,std` passes on x86_64-linux.
- Verified `cargo check --no-default-features --features runtime` passes on x86_64-linux.